### PR TITLE
Support layer compositing and alpha

### DIFF
--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -466,7 +466,7 @@ struct PaintGroup
 struct PaintComposite
 {
   uint16              format; // = 5
-  BlendMode           blend;
+  Composite           composite;
   uint16              dest_gid;
 };
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -21,6 +21,7 @@ December 2019
   * [Linear Gradients](#linear-gradients)
   * [Radial Gradients](#radial-gradients)
 - [Group](#group)
+- [Compositing](#compositing)
 - [Structure of gradient COLR v1 extensions](#structure-of-gradient-colr-v1-extensions)
 - [Implementation](#implementation)
   * [Font Tooling](#font-tooling)
@@ -268,16 +269,17 @@ Concretely, a group reuses another glyph with alpha and transform applied. For e
    - Define a glyph for the hour-hand of the clock
    - Define N o’clock as the 12 marks untransformed, plus the hour-hand rotated
 
-The `LayerV1Glyph` `gid` field is resolved per [Self-referential gids](#self-referential-gids).
+The `LayerV1Glyph` `gid` field is resolved per [self-referential gids](#self-referential-gids).
 
-# Composite
+# Compositing
 
-By default layers are drawn on top of each other. Composite permits a variety of additional methods of combining layers.
+By default layers are drawn on top of each other. Composite permits a variety of additional methods by specifying two glyphs to be combined according to a well defined
+algorithm.
 
 The compositing algorithms are specified by https://www.w3.org/TR/compositing-1/, with
 one exception: Alpha Channel. For alpha channel the dest colors are converted to the alpha channel for source by averaging the (R, G, B) parts.
 
-The `LayerV1Glyph` `gid` and the `PaintBlend` `dest_gid` are resolved per [Self-referential gids](#self-referential-gids).
+The `LayerV1Glyph` `gid` and the `PaintBlend` `dest_gid` are resolved per [self-referential gids](#self-referential-gids).
 
 
 # Self-referential gids


### PR DESCRIPTION
Strawman for compositing support beyond just over. 

- Modes are as per https://www.w3.org/TR/compositing-1/
   - Most implementations support most modes, I have optimistically assumed that adding one or two isn't a deal breaker
      - D2D is notable in that it seems to have relatively few of the modes
      - sources
         - https://developer.apple.com/documentation/coregraphics/cgblendmode?language=objc
         - https://www.cairographics.org/operators/
         - https://docs.microsoft.com/en-us/windows/win32/api/d2d1_1/ne-d2d1_1-d2d1_composite_mode
         - https://source.chromium.org/chromium/chromium/src/+/master:third_party/skia/include/core/SkBlendMode.h
- Alpha support is added as a bonus composite mode
   - Allows use of another glyph as the alpha channel
   - This supports the desire for alpha gradients that has come up a few times

I attempted to follow the `PaintGroup` model and only force glyphs to "pay" bytes for compositing when actually used by making a new `Paint` instead of adding flags to the `LayerV1Record`.

Fixes #13.

Edit: the diff is a bit hard to read, https://github.com/googlefonts/colr-gradients-spec/blob/rs/colr-gradients-spec.md#compositing shows the updated md.