### PR TITLE
Support layer compositing and alpha, mk2

### DIFF
--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -85,7 +85,7 @@ are defined:
 1. **Transformed** reuses another paint, applying an affine transformation
 1. **Composite** reuses two other paints, applying a compositing rule to combine them
    * We draw on https://www.w3.org/TR/compositing-1/ for our composite modes
-1. **Glyph** draws a non-COLR glyph, filled using a type 1, 2, or 3 paint.
+1. **Glyph** draws a non-COLR glyph
    * A COLR v1 glyph made up of a list of Glyph paints is equivalent to a COLR v0 Layer Record with the added ability to use gradients.
 1. **Colr Glyph** reuses a COLR v1 glyph at a new position in the graph
 
@@ -468,12 +468,11 @@ struct PaintComposite
 // Paint a non-COLR glyph, filled as indicated by paint.
 // Akin to the COLRv0 Layer Record.
 // Clip paint to the region inked by gid
-// Paint must be unbounded
 struct PaintGlyph
 {
   uint8               format; // = 6
   uint16              gid;    // shall not be a COLR gid
-  Offset16<Paint>     paint;  // shall be format 1, 2, or 3
+  Offset16<Paint>     paint;
 }
 
 struct PaintColrGlyph

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -466,7 +466,7 @@ struct PaintGroup
 struct PaintComposite
 {
   uint16              format; // = 5
-  BlendMode           blend;
+  Composite           composite;
   uint16              dest_gid;
 };
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -22,6 +22,7 @@ December 2019
   * [Radial Gradients](#radial-gradients)
 - [Reusable Parts](#reusable-parts)
 - [Acyclic Graphs Only](#acyclic-graphs-only)
+- [Alpha](#alpha)
 - [Structure of gradient COLR v1 extensions](#structure-of-gradient-colr-v1-extensions)
 - [Implementation](#implementation)
   * [Font Tooling](#font-tooling)
@@ -274,6 +275,14 @@ The hour hand is reusable as a transformed glyph.
 Another example might be emoji faces: many have the same backdrop
 with different eyes, noses, tears, etc drawn on top.
 
+# Alpha
+
+The alpha channel for a layer can be populated using `PaintComposite`:
+
+- `PaintSolid` can be used to set a blanket alpha
+- `PaindLinearGradient` and `PaintRadialGradient` can be set gradient alpha
+- Mode [Source In](https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcin) can be used to mask
+
 # Acyclic Graphs Only
 
 `PaintColrGlyph` allows recursive composition of COLR glyphs. This
@@ -440,10 +449,6 @@ struct PaintTransformed
   Affine2x3           transform;
 };
 
-// Set alpha using Source In
-//    - a solid color can set uniform alpha
-//    - a gradient can set less uniform alpha
-//    - a glyph painted in alpha can be used to mask
 struct PaintComposite
 {
   uint8               format; // = 5
@@ -466,7 +471,6 @@ struct PaintColrGlyph
   uint8               format; // = 7
   uint16              gid;    // shall be a COLR gid
 }
-
 
 // Glyph root
 // NOTE: uint8 size saves bytes in most cases and does not

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -5,6 +5,7 @@ December 2019
 ### Authors:
 * Behdad Esfahbod ([@behdad](https://github.com/behdad))
 * Dominik Röttsches ([@drott](https://github.com/drott))
+* Roderick Sheeter ([@rsheeter](https://github.com/rsheeter))
 
 ## Table of Contents
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -81,7 +81,8 @@ COLR table is extended to expose a new vector of layers per glyph.  If a glyph
 is not found in the new vector, client will try finding it in the COLR v0 glyph
 vector and fall back to no-color if the glyph is not found there either.
 
-A glyph using the new extension is mapped to a list of layers. Each layers is formed by a directed acyclic graph of paints. Several different types of paint
+A glyph using the new extension is mapped to a list of layers. Each layer is
+formed by a directed acyclic graph of paints. Several different types of paint
 are defined:
 
 1. **Solid** paints a solid color

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -259,7 +259,7 @@ transforms.
 The alpha channel for a layer can be populated using `PaintComposite`:
 
 - `PaintSolid` can be used to set a blanket alpha
-- `PaindLinearGradient` and `PaintRadialGradient` can be set gradient alpha
+- `PaindLinearGradient` and `PaintRadialGradient` can be used to set gradient alpha
 - Mode [Source In](https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcin) can be used to mask
 
 # Reusable Parts

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -517,8 +517,6 @@ struct PaintComposite
 };
 
 // Paint a non-COLR glyph, filled as indicated by paint.
-// Akin to the COLRv0 Layer Record.
-// Clip paint to the region inked by gid
 struct PaintGlyph
 {
   uint8               format; // = 6
@@ -534,7 +532,7 @@ struct PaintColrGlyph
 
 // Glyph root
 // NOTE: uint8 size saves bytes in most cases and does not
-// preclude use of large layer counts via PaintComposite OVER
+// preclude use of large layer counts via PaintComposite.
 typedef ArrayOf<Offset16<Paint>, uint8> LayerV1List;
 
 // Each layer is OVER previous

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -21,6 +21,7 @@ December 2019
   * [Linear Gradients](#linear-gradients)
   * [Radial Gradients](#radial-gradients)
 - [Group](#group)
+- [Compositing](#compositing)
 - [Structure of gradient COLR v1 extensions](#structure-of-gradient-colr-v1-extensions)
 - [Implementation](#implementation)
   * [Font Tooling](#font-tooling)
@@ -268,16 +269,17 @@ Concretely, a group reuses another glyph with alpha and transform applied. For e
    - Define a glyph for the hour-hand of the clock
    - Define N o’clock as the 12 marks untransformed, plus the hour-hand rotated
 
-The `LayerV1Glyph` `gid` field is resolved per [Self-referential gids](#self-referential-gids).
+The `LayerV1Glyph` `gid` field is resolved per [self-referential gids](#self-referential-gids).
 
-# Composite
+# Compositing
 
-By default layers are drawn on top of each other. Composite permits a variety of additional methods of combining layers.
+By default layers are drawn on top of each other. Composite permits a variety of additional methods by specifying two glyphs to be combined according to a well defined
+algorithm.
 
 The compositing algorithms are specified by https://www.w3.org/TR/compositing-1/, with
 one exception: Alpha Channel. For alpha channel the dest colors are converted to the alpha channel for source by averaging the (R, G, B) parts.
 
-The `LayerV1Glyph` `gid` and the `PaintBlend` `dest_gid` are resolved per [Self-referential gids](#self-referential-gids).
+The `LayerV1Glyph` `gid` and the `PaintBlend` `dest_gid` are resolved per [self-referential gids](#self-referential-gids).
 
 
 # Self-referential gids

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -342,10 +342,11 @@ The following paints *may* be bounded:
 
 ## Bounding Box
 
-To simplify implementation allocation of drawing surface the
-`BaseGlyphV1Record` `gid` entry in the `glyf` table must provide
-the bounding box for the final COLR glyph by providing two
-on-curve points, one at `(min-x, min-y)` and one at `(max-x, max-y)`.
+To simplify implementation allocation of a drawing surface the
+bounding box of the glyph corresponding to the `BaseGlyphV1Record`
+should be taken to describe the drawing area for the COLR v1 glyph.
+
+Note: A `glyf` entry with two points at the diagonal extrema would suffice.
 
 # Structure of gradient COLR v1 extensions
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -21,10 +21,12 @@ December 2019
       - [Extend Reflect](#extend-reflect)
   * [Linear Gradients](#linear-gradients)
   * [Radial Gradients](#radial-gradients)
-- [Alpha](#alpha)
-- [Reusable Parts](#reusable-parts)
-- [Acyclic Graphs Only](#acyclic-graphs-only)
-- [Bounded Layers Only](#bounded-layers-only)
+- [Understanding the format](#understanding-the-format)
+   - [Alpha](#alpha)
+   - [Reusable Parts](#reusable-parts)
+   - [Acyclic Graphs Only](#acyclic-graphs-only)
+   - [Bounded Layers Only](#bounded-layers-only)
+   - [Bounding Box](#bounding-box)
 - [Structure of gradient COLR v1 extensions](#structure-of-gradient-colr-v1-extensions)
 - [Implementation](#implementation)
   * [Font Tooling](#font-tooling)
@@ -264,7 +266,9 @@ inverse-transform approach noted above can fall back to a linear-gradient
 combined with a clipping path to achieve proper rendering of problematic affine
 transforms.
 
-# Alpha
+# Understanding the format
+
+## Alpha
 
 The alpha channel for a layer can be populated using `PaintComposite`:
 
@@ -272,7 +276,7 @@ The alpha channel for a layer can be populated using `PaintComposite`:
 - `PaindLinearGradient` and `PaintRadialGradient` can be used to set gradient alpha
 - Mode [Source In](https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcin) can be used to mask
 
-# Reusable Parts
+## Reusable Parts
 
 Use `PaintTransformed` to reuse parts in different positions or sizes.
 
@@ -293,14 +297,14 @@ The hour hand is reusable as a transformed glyph.
 Another example might be emoji faces: many have the same backdrop
 with different eyes, noses, tears, etc drawn on top.
 
-# Acyclic Graphs Only
+## Acyclic Graphs Only
 
 `PaintColrGlyph` allows recursive composition of COLR glyphs. This
 is desirable for reusable parts but introduces the possibility of
 a cyclic graph. Implementations should track the COLR gids they have
 seen in processing and fail if a gid is reached repeatedly.
 
-# Bounded Layers Only
+## Bounded Layers Only
 
 Every entry in the `LayerV1List` must define a bounded region.
 Implementations must confirm this invariant. Unbounded layers must
@@ -335,7 +339,16 @@ The following paints *may* be bounded:
    - Bounded IFF src AND backdrop are bounded
       - *all other modes*
 
+## Bounding Box
+
+To simplify implementation allocation of drawing surface the
+`BaseGlyphV1Record` `gid` entry in the `glyf` table must provide
+the bounding box for the final COLR glyph by providing two
+on-curve points, one at `(min-x, min-y)` and one at `(max-x, max-y)`.
+
 # Structure of gradient COLR v1 extensions
+
+Offsets are always relative to the start of the containing struct.
 
 ```C++
 // Base types

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -20,9 +20,9 @@ December 2019
       - [Extend Reflect](#extend-reflect)
   * [Linear Gradients](#linear-gradients)
   * [Radial Gradients](#radial-gradients)
+- [Alpha](#alpha)
 - [Reusable Parts](#reusable-parts)
 - [Acyclic Graphs Only](#acyclic-graphs-only)
-- [Alpha](#alpha)
 - [Structure of gradient COLR v1 extensions](#structure-of-gradient-colr-v1-extensions)
 - [Implementation](#implementation)
   * [Font Tooling](#font-tooling)
@@ -254,6 +254,14 @@ inverse-transform approach noted above can fall back to a linear-gradient
 combined with a clipping path to achieve proper rendering of problematic affine
 transforms.
 
+# Alpha
+
+The alpha channel for a layer can be populated using `PaintComposite`:
+
+- `PaintSolid` can be used to set a blanket alpha
+- `PaindLinearGradient` and `PaintRadialGradient` can be set gradient alpha
+- Mode [Source In](https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcin) can be used to mask
+
 # Reusable Parts
 
 Use `PaintTransformed` to reuse parts in different positions or sizes.
@@ -274,14 +282,6 @@ The hour hand is reusable as a transformed glyph.
 
 Another example might be emoji faces: many have the same backdrop
 with different eyes, noses, tears, etc drawn on top.
-
-# Alpha
-
-The alpha channel for a layer can be populated using `PaintComposite`:
-
-- `PaintSolid` can be used to set a blanket alpha
-- `PaindLinearGradient` and `PaintRadialGradient` can be set gradient alpha
-- Mode [Source In](https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcin) can be used to mask
 
 # Acyclic Graphs Only
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -23,6 +23,7 @@ December 2019
 - [Alpha](#alpha)
 - [Reusable Parts](#reusable-parts)
 - [Acyclic Graphs Only](#acyclic-graphs-only)
+- [Bounded Layers Only](#bounded-layers-only)
 - [Structure of gradient COLR v1 extensions](#structure-of-gradient-colr-v1-extensions)
 - [Implementation](#implementation)
   * [Font Tooling](#font-tooling)
@@ -297,6 +298,41 @@ with different eyes, noses, tears, etc drawn on top.
 is desirable for reusable parts but introduces the possibility of
 a cyclic graph. Implementations should track the COLR gids they have
 seen in processing and fail if a gid is reached repeatedly.
+
+# Bounded Layers Only
+
+Every entry in the `LayerV1List` must define a bounded region.
+Implementations must confirm this invariant. Unbounded layers must
+not render.
+
+The following paints are always bounded:
+
+- `PaintGlyph`
+- `PaintColrGlyph`
+
+The following paints are always unbounded:
+
+- `PaintSolid`
+- `PaintLinearGradient`
+- `PaintRadialGradient`
+
+The following paints *may* be bounded:
+
+- `PaintTransformed` is bounded IFF the source is bounded
+- `PaintComposite` boundedness varies by mode:
+   - Always bounded
+      - `COMPOSITE_CLEAR`
+   - Bounded IFF src is bounded
+      - `COMPOSITE_SRC`
+      - `COMPOSITE_SRC_OUT`
+   - Bounded IFF backdrop is bounded
+      - `COMPOSITE_DEST`
+      - `COMPOSITE_DEST_OUT`
+   - Bounded IFF src OR backdrop is bounded
+      - `COMPOSITE_SRC_IN`
+      - `COMPOSITE_DEST_IN`
+   - Bounded IFF src AND backdrop are bounded
+      - *all other modes*
 
 # Structure of gradient COLR v1 extensions
 

--- a/images/clock-1.svg
+++ b/images/clock-1.svg
@@ -1,0 +1,21 @@
+<svg enable-background="new 0 0 128 128" viewBox="0 0 128 128"
+  xmlns="http://www.w3.org/2000/svg" width="256">
+  <linearGradient id="a" x1="64" x2="64" y1="19.751" y2="111.99" gradientUnits="userSpaceOnUse">
+    <stop stop-color="#ECEFF1" offset=".3212"/>
+    <stop stop-color="#B0BEC5" offset="1"/>
+  </linearGradient>
+  <circle cx="64" cy="64" r="60" fill="url(#a)"/>
+  <path d="m63.8 63.98h0.4c2.1 0 3.8-1.7 3.8-3.8v-32.4c0-2.1-1.7-3.8-3.8-3.8h-0.4c-2.1 0-3.8 1.7-3.8 3.8v32.4c0 2.1 1.7 3.8 3.8 3.8z"/>
+  <path d="m63.7 63.88 0.34 0.21c1.79 1.1 4.13 0.55 5.23-1.24l11.34-18.37c1.1-1.79 0.55-4.13-1.24-5.23l-0.34-0.21c-1.79-1.1-4.13-0.55-5.23 1.24l-11.33 18.37c-1.1 1.79-0.55 4.13 1.23 5.23z" fill="green"/>
+  <circle cx="64" cy="64" r="7" fill="#424242"/>
+  <circle cx="64" cy="64" r="3" fill="#fff"/>
+  <g fill="#757575">
+      <circle cx="15.89" cy="64.13" r="4"/>
+      <circle cx="63.89" cy="16.13" r="4"/>
+      <circle cx="63.89" cy="112.13" r="4"/>
+      <circle cx="111.89" cy="64.13" r="4"/>
+  </g>
+  <g opacity=".2">
+    <path d="M64,8c30.88,0,56,25.12,56,56s-25.12,56-56,56S8,94.88,8,64S33.12,8,64,8 M64,4 C30.86,4,4,30.86,4,64s26.86,60,60,60s60-26.86,60-60S97.14,4,64,4L64,4z" fill="#424242"/>
+  </g>
+</svg>

--- a/images/clock-2.svg
+++ b/images/clock-2.svg
@@ -1,0 +1,21 @@
+<svg enable-background="new 0 0 128 128" viewBox="0 0 128 128"
+  xmlns="http://www.w3.org/2000/svg" width="256">
+  <linearGradient id="a" x1="64" x2="64" y1="19.751" y2="111.99" gradientUnits="userSpaceOnUse">
+    <stop stop-color="#ECEFF1" offset=".3212"/>
+    <stop stop-color="#B0BEC5" offset="1"/>
+  </linearGradient>
+  <circle cx="64" cy="64" r="60" fill="url(#a)"/>
+  <path d="m63.8 63.98h0.4c2.1 0 3.8-1.7 3.8-3.8v-32.4c0-2.1-1.7-3.8-3.8-3.8h-0.4c-2.1 0-3.8 1.7-3.8 3.8v32.4c0 2.1 1.7 3.8 3.8 3.8z"/>
+  <path d="m63.78 63.81 0.19 0.35c1.01 1.84 3.32 2.52 5.16 1.51l18.94-10.36c1.84-1.01 2.52-3.32 1.51-5.16l-0.19-0.35c-1.01-1.84-3.32-2.52-5.16-1.51l-18.94 10.36c-1.84 1.01-2.52 3.32-1.51 5.16z" fill="green"/>
+  <circle cx="64" cy="64" r="7" fill="#424242"/>
+  <circle cx="64" cy="64" r="3" fill="#fff"/>
+  <g fill="#757575">
+    <circle cx="15.89" cy="64.13" r="4"/>
+    <circle cx="63.89" cy="16.13" r="4"/>
+    <circle cx="63.89" cy="112.13" r="4"/>
+    <circle cx="111.89" cy="64.13" r="4"/>
+  </g>
+  <g opacity=".2">
+    <path d="M64,8c30.88,0,56,25.12,56,56s-25.12,56-56,56S8,94.88,8,64S33.12,8,64,8 M64,4 C30.86,4,4,30.86,4,64s26.86,60,60,60s60-26.86,60-60S97.14,4,64,4L64,4z" fill="#424242"/>
+  </g>
+</svg>

--- a/images/clock-common.svg
+++ b/images/clock-common.svg
@@ -1,0 +1,20 @@
+<svg enable-background="new 0 0 128 128" viewBox="0 0 128 128"
+  xmlns="http://www.w3.org/2000/svg" width="256">
+  <linearGradient id="a" x1="64" x2="64" y1="19.751" y2="111.99" gradientUnits="userSpaceOnUse">
+    <stop stop-color="#ECEFF1" offset=".3212"/>
+    <stop stop-color="#B0BEC5" offset="1"/>
+  </linearGradient>
+  <circle cx="64" cy="64" r="60" fill="url(#a)"/>
+  <path d="m63.8 63.98h0.4c2.1 0 3.8-1.7 3.8-3.8v-32.4c0-2.1-1.7-3.8-3.8-3.8h-0.4c-2.1 0-3.8 1.7-3.8 3.8v32.4c0 2.1 1.7 3.8 3.8 3.8z"/>
+  <circle cx="64" cy="64" r="7" fill="#424242"/>
+  <circle cx="64" cy="64" r="3" fill="#fff"/>
+  <g fill="#757575">
+      <circle cx="15.89" cy="64.13" r="4"/>
+      <circle cx="63.89" cy="16.13" r="4"/>
+      <circle cx="63.89" cy="112.13" r="4"/>
+      <circle cx="111.89" cy="64.13" r="4"/>
+  </g>
+  <g opacity=".2">
+    <path d="M64,8c30.88,0,56,25.12,56,56s-25.12,56-56,56S8,94.88,8,64S33.12,8,64,8 M64,4 C30.86,4,4,30.86,4,64s26.86,60,60,60s60-26.86,60-60S97.14,4,64,4L64,4z" fill="#424242"/>
+  </g>
+</svg>


### PR DESCRIPTION
Take two (take 1 was #35) at layer compositing and alpha. Changes layer structure to a DAG based on chat with @behdad and @drott. 

- Modes are as per https://www.w3.org/TR/compositing-1/
   - Most implementations already support most modes
      - D2D is notable in that it seems to have relatively few of the modes
      - sources
         - https://developer.apple.com/documentation/coregraphics/cgblendmode?language=objc
         - https://www.cairographics.org/operators/
         - https://docs.microsoft.com/en-us/windows/win32/api/d2d1_1/ne-d2d1_1-d2d1_composite_mode
         - https://source.chromium.org/chromium/chromium/src/+/master:third_party/skia/include/core/SkBlendMode.h

Fixes #13.

The diff is a bit hard to read, https://github.com/googlefonts/colr-gradients-spec/blob/rs/colr-gradients-spec.md#compositing shows the updated md.

Edit: I believe this fixes #3 given that you get layers and `PaintComposite` can be used for hole-punching via [Source Out](https://www.w3.org/TR/compositing-1/#porterduffcompositingoperators_srcout).

Edit2: Note that I changed Extend and the Paint format to `uint8` instead of `uint16`; @anthrotype pointed out that I neglected to highlight this (ty).