### PR TITLE
Rename PaintFilledGlyph to PaintClipGlyph

### DIFF
--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -88,7 +88,7 @@ are defined:
 1. **Solid** paints a solid color
 1. **Linear gradient** paints a linear gradient
 1. **Radial gradient** paints a radial gradient
-1. **Filled Glyph** draws a non-COLR glyph
+1. **Clip Glyph** draws a non-COLR glyph
    * A COLR v1 glyph made up of a list of Glyph paints is equivalent to a COLR v0 Layer Record with the added ability to use gradients.
 1. **COLR Glyph** reuses a COLR v1 glyph at a new position in the graph
 1. **Transformed** reuses another paint, applying an affine transformation
@@ -304,7 +304,7 @@ not render.
 
 The following paints are always bounded:
 
-- `PaintFilledGlyph`
+- `PaintClipGlyph`
 - `PaintColrGlyph`
 
 The following paints are always unbounded:
@@ -488,8 +488,9 @@ struct PaintRadialGradient
   VarUFWORD           radius1;
 };
 
-// Paint a non-COLR glyph, filled as indicated by paint.
-struct PaintFilledGlyph
+// Paint a non-COLR glyph, drawing region clipped to shape defined by gid,
+// filled as indicated by paint.
+struct PaintClipGlyph
 {
   uint8               format; // = 4
   Offset24<Paint>     paint;
@@ -564,7 +565,7 @@ font formats, including COLR v1.
 Allocate a bitmap for the glyph according to glyf table entry extents for gid
 0) Traverse layers for gid, add current gid to blacklist *1
  a) Paint a paint, switch:
-    1) PaintFilledGlyph
+    1) PaintClipGlyph
          gid must not COLRv1
          saveLayer
          setClipPath to gid path


### PR DESCRIPTION
`PaintClipGlyph` more clearly describes what graphics context operation is
executed before nested paints are executed.