### PR TITLE
make PaintRadialGradient use Offset24

### DIFF
--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -498,7 +498,7 @@ For linear gradient without skew, set x2,y2 to x1,y1.
 
 |Type | Field name | Description |
 |-|-|-|
-| uint16 | format | set to 3 |
+| uint8 | format | set to 3 |
 | Offset24 | colorLineOffset | offset from start of PaintRadialGradient table |
 | VarFWord | x0 | start circle center x coordinate |
 | VarFWord | y0 | start circle center y coordinate |

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -499,7 +499,7 @@ For linear gradient without skew, set x2,y2 to x1,y1.
 |Type | Field name | Description |
 |-|-|-|
 | uint16 | format | set to 3 |
-| Offset32 | colorLineOffset | offset from start of PaintRadialGradient table |
+| Offset24 | colorLineOffset | offset from start of PaintRadialGradient table |
 | VarFWord | x0 | start circle center x coordinate |
 | VarFWord | y0 | start circle center y coordinate |
 | VarUFWord | radius0 | start circle radius |


### PR DESCRIPTION
The C++ templates were updated in https://github.com/googlefonts/colr-gradients-spec/pull/59 to use `Offset24` for PaintRadialGradient's offset to ColorLine. However the table definition still had the old `uint16` format and `Offset32`.
Make the table definition match the C++ template and use `uint8` format and `Offset24`.