### PR TITLE
Allow reuse of a subset of the layers of another COLR glyph

### DIFF
--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -871,7 +871,7 @@ struct PaintColrSlice
   uint8               format; // = 5
   uint16              gid;    // shall be a COLR gid
   uint8               firstLayerIndex;
-  uint8               lastLayer;
+  uint8               lastLayerIndex;
 }
 
 struct PaintTransformed

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -567,7 +567,7 @@ If compositeMode value is not recognized, COMPOSITE_CLEAR is used.
 |-|-|-|
 | uint8 | format | Set to 8. |
 | uint8 | numLayers | Number of offsets to Paint to read from layers. |
-| uint32 | firstLayerIndex | Index into the LayerV1List referenced by the COLR v1 header. |
+| uint32 | firstLayerIndex | Index into the LayerV1List. |
 
 Each layer is composited on top of previous with mode COMPOSITE_SRC_OVER.
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -386,7 +386,7 @@ Offsets are always relative to the start of the containing struct.
 | Type | Name | Description |
 |-|-|-|
 | uint16 | glyphID | Glyph ID of the base glyph. |
-| Offset32 | layerListOffset | Offset to LayerV1List table, from start of BaseGlyphsV1List table. |
+| Offset32 | paintOffset | Offset to Paint, typically a `PaintColrLayers` |
 
 *Note:* The glyph ID is not limited to the numGlyphs value in the &#39;maxp&#39; table.
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -524,7 +524,7 @@ Glyph outline is used as clip mask for the content in the Paint subtable. Glyph 
 | uint8 | format | Set to 5. |
 | uint16 | glyphID | Virtual glyph ID for a BaseGlyphV1List base glyph. |
 | uint8 | firstLayer | First layer to take from the glyph identified by glyphID  |
-| uint8 | lastLayer | Last layer to take from the glyph identified by glyphID |
+| uint8 | lastLayerIndex | Index of the last layer to take from the glyph identified by glyphID |
 
 Glyph ID must be in the BaseGlyphV1List; may be greater than maxp.numGlyphs.
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -870,7 +870,7 @@ struct PaintColrSlice
 {
   uint8               format; // = 5
   uint16              gid;    // shall be a COLR gid
-  uint8               firstLayer;
+  uint8               firstLayerIndex;
   uint8               lastLayer;
 }
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -532,6 +532,9 @@ the `PaintColrSlice` is invalid. If lastLayerIndex > the number of
 layers available in the base glyph then all layers from firstLayerIndex
 to the last available layer should be retained.
 
+A range 0..255 therefore means "all available layers." A range 0..0 means
+just the first layer.
+
 ##### PaintTransformed table (format 6)
 
 | Type | Field name | Description |

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -523,10 +523,14 @@ Glyph outline is used as clip mask for the content in the Paint subtable. Glyph 
 |-|-|-|
 | uint8 | format | Set to 5. |
 | uint16 | glyphID | Virtual glyph ID for a BaseGlyphV1List base glyph. |
-| uint8 | firstLayer | First layer to take from the glyph identified by glyphID  |
-| uint8 | lastLayerIndex | Index of the last layer to take from the glyph identified by glyphID |
+| uint8 | firstLayerIndex | First layer to take from the glyph identified by glyphID. 0-based. |
+| uint8 | lastLayerIndex | Index of the last layer to take from the glyph identified by glyphID, inclusive. 0-based. |
 
-Glyph ID must be in the BaseGlyphV1List; may be greater than maxp.numGlyphs.
+Glyph ID must be in the BaseGlyphV1List; may be greater than maxp.numGlyphs. If firstLayerIndex is greater than the number of layers
+available in the base glyph or lastLayerIndex < firstLayerIndex
+the `PaintColrSlice` is invalid. If lastLayerIndex > the number of
+layers available in the base glyph then all layers from firstLayerIndex
+to the last available layer should be retained.
 
 ##### PaintTransformed table (format 6)
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -569,7 +569,7 @@ If compositeMode value is not recognized, COMPOSITE_CLEAR is used.
 | uint8 | numLayers | Number of offsets to Paint to read from layers. |
 | uint32 | firstLayerIndex | Index into the LayerV1List referenced by the COLR v1 header. |
 
-Each layer is COMPOSITE_SRC_OVER previous.
+Each layer is composited on top of previous with mode COMPOSITE_SRC_OVER.
 
 *Note:* uint8 size saves bytes in most cases. Large layer counts can be
 achieved by way of PaintComposite or a tree of PaintColrLayers.
@@ -662,7 +662,7 @@ def paint(paint, active_paints)
 ##### Bounded Layers Only
 
 The `BaseGlyphV1Record` paint must define a bounded region. That is,
-is must paint within an area for which a bounding box could be
+is must paint within an area for which a finite bounding box could be
 defined. Implementations must confirm this invariant.
 A `BaseGlyphV1Record` with an unbounded paint must not render.
 
@@ -938,7 +938,7 @@ struct PaintComposite
   Offset24<Paint>     backdrop;
 };
 
-// Each layer is COMPOSITE_SRC_OVER previous
+// Each layer is composited on top of previous with mode COMPOSITE_SRC_OVER.
 // NOTE: uint8 size saves bytes in most cases and does not
 // preclude use of large layer counts via PaintComposite or a tree
 // of PaintColrLayers.


### PR DESCRIPTION
Allow reuse of a slice of another COLR glyph

Fixes #86 

EDIT: generalized to a new paint format that points to a series of paint pointers, ty @behdad 