### PR TITLE
misc tweaks

### DIFF
--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -620,10 +620,10 @@ Supported composition modes are taken from the W3C [Compositing and Blending Lev
 
 | Type | Name | Description |
 |-|-|-|
-| VarFixed | xx | x-component of transformed x-basis vector (*î*) |
-| VarFixed | yx | y-component of transformed x-basis vector (*î*) |
-| VarFixed | xy | x-component of transformed y-basis vector (*ĵ*) |
-| VarFixed | yy | y-component of transformed y-basis vector (*ĵ*) |
+| VarFixed | xx | x-component of transformed x-basis vector |
+| VarFixed | yx | y-component of transformed x-basis vector |
+| VarFixed | xy | x-component of transformed y-basis vector |
+| VarFixed | yy | y-component of transformed y-basis vector |
 | VarFixed | dx | Translation in x direction. |
 | VarFixed | dy | Translation in y direction. |
 


### PR DESCRIPTION
Main changes are in description of Affine2x3. As @drott commented in #85,

> as the matrix does not contain basis vectors, but coefficients

So `x-part of x-basis vector` is not really correct. (By convention, the x-part of the x-basis vector would always be 1! The matrix coefficients related to how the basis vector _gets transformed_.)

I separated `_v' = M * v =...` into two lines for better clarity. (The "," gets lost.)

`def paint` isn't prototypical pseudocode; it's Python, and could be unfamiliar to many readers.