### PR TITLE
Update 5.7.11.1.9 to cover well-formedness/validity

### DIFF
--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -1454,14 +1454,14 @@ graph, checking whether any paint table was already encountered within that
 path. The following pseudo-code algorithm can be used:
 
 ```
-    // called initially with the root paint and an empty set activePaints
-    function paintIsAcyclic(paint, activePaints)
-        if paint is in activePaints
+    // called initially with the root paint and an empty set pathPaints
+    function paintIsAcyclic(paint, pathPaints)
+        if paint is in pathPaints
           return false // cycle detected
-        add paint to activePaints
+        add paint to pathPaints
         for each childPaint referenced by paint as a child subtable
-          call paintIsAcyclic(childPaint, activePaints)
-        remove paint from activePaints
+          call paintIsAcyclic(childPaint, pathPaints)
+        remove paint from pathPaints
 ```
 
 For the graph to be valid, it shall also be visually bounded, as described in

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -1432,12 +1432,12 @@ Thus, the generalization that can be made regarding the relationship between the
 number of layers and the nature of the graph is that the number of distinct
 root-to-leaf paths will be greater than or equal to the number of layers.
 
-The following are required for the graph to be well-formed:
+The following are necessary for the graph to be well-formed and valid:
 
-* All subtable links shall be valid:
+* All subtable links shall satisfy the following criteria:
   * Forward offsets are within the COLR table bounds.
-  * If a PaintColrLayers table is present, a LayersV1List is present, and the
-referenced slice is within the length of the LayersV1List.
+  * If a PaintColrLayers table is present, then a LayersV1List is also present,
+and the referenced slice is within the length of the LayersV1List.
   * If a PaintColrGlyph table is present, there is a BaseGlyphV1Record for the
 referenced base glyph ID.
 * The graph shall be acyclic.
@@ -1468,7 +1468,7 @@ within that sequence. The following pseudo-code algorithm can be used:
 NOTE: Implementations can combine testing for cycles and other well-formedness
 requirements together with other processing for rendering the color glyph.
 
-For the graph to be valid, it shall be visually bounded, as described in
+For the graph to be valid, it shall also be visually bounded, as described in
 5.7.11.1.8.2.
 
 If the graph is not well formed, the entire color glyph definition should be

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -957,9 +957,8 @@ by the child sub-graph.
 **Figure 5.18 A PaintGlyph table defines a clip region for the composition defined by its child sub-graph.**
 
 A PaintGlyph table on its own does not add content: if there is no child paint
-table, then the PaintGlyph table represents no presentation content and shall be
-ignored. This could result in the entire color glyph definition being invalid.
-See 5.7.11.1.9 for additional information.
+table, then the graph is not well formed. See 5.7.11.1.9 for details regarding
+well-formedness and validity of the graph.
 
 **5.7.11.1.4 Layering**
 
@@ -1314,7 +1313,8 @@ not related to glyph IDs used in any other tables.
 
 When a PaintColrGlyph table is used, a BaseGlyphV1Record with the specified
 glyph ID is expected. If no BaseGlyphV1Record with that glyph ID is found, the
-color glyph should be ignored. See 5.7.11.1.9 for additional information.
+color glyph is not well formed. See 5.7.11.1.9 for details regarding
+well-formedness and validity of the graph.
 
 The example from 5.7.11.1.7.2 is modified to illustrate use of a PaintColrGlyph
 table. In the following figure, a PaintColrLayers table references a slice
@@ -1440,9 +1440,10 @@ The following are required for the graph to be well-formed:
 referenced slice is within the length of the LayersV1List.
   * If a PaintColrGlyph table is present, there is a BaseGlyphV1Record for the
 referenced base glyph ID.
-* The graph shall be finite and acyclic (without cycles).
-* All leaf nodes shall be one of PaintSolid, PaintLinearGradient or
-PaintRadialGradient.
+* The graph shall be acyclic.
+
+NOTE: These constraints imply that all leaf nodes will be one of PaintSolid,
+PaintLinearGradient or PaintRadialGradient.
 
 For the graph to be acyclic, no paint table shall have any child or descendent
 paint table that is also its parent or ancestor within the graph. In particular,
@@ -1463,6 +1464,9 @@ within that sequence. The following pseudo-code algorithm can be used:
           call paintIsAcyclic(childPaint, activePaints)
         remove paint from activePaints
 ```
+
+NOTE: Implementations can combine testing for cycles and other well-formedness
+requirements together with other processing for rendering the color glyph.
 
 For the graph to be valid, it shall be visually bounded, as described in
 5.7.11.1.8.2.

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -1470,14 +1470,12 @@ requirements together with other processing for rendering the color glyph.
 For the graph to be valid, it shall also be visually bounded, as described in
 5.7.11.1.8.2.
 
-If the graph is not well formed, the entire color glyph definition should be
-considered invalid.  Similarly, if an application encounters a paint table with
-an unrecognized format (which could be introduced in a later minor version
-update of the COLR table), the color glyph should be ignored. If the base glyph
-ID has an outline, that may be rendered as a non-color glyph instead.
-
-NOTE: If a sub-graph is ignored, the remainder of the graph could be visually
-unbounded and, therefore, invalid.
+If a sub-graph is ignored, the remainder of the graph could be visually
+unbounded and, therefore, invalid. This should be considered when devising a
+fallback strategy if an errors are detected while parsing the graph, or an
+unrecognized paint format is encountered. Applications may ignore the color
+glyph entirely in such cases. If the base glyph ID has an outline, that may be
+rendered as a non-color glyph instead.
 
 **5.7.11.2 COLR table formats**
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -1464,18 +1464,28 @@ path. The following pseudo-code algorithm can be used:
         remove paint from activePaints
 ```
 
-NOTE: Implementations can combine testing for cycles and other well-formedness
-requirements together with other processing for rendering the color glyph.
-
 For the graph to be valid, it shall also be visually bounded, as described in
 5.7.11.1.8.2.
 
-If a sub-graph is ignored, the remainder of the graph could be visually
-unbounded and, therefore, invalid. This should be considered when devising a
-fallback strategy if an errors are detected while parsing the graph, or an
-unrecognized paint format is encountered. Applications may ignore the color
-glyph entirely in such cases. If the base glyph ID has an outline, that may be
-rendered as a non-color glyph instead.
+NOTE: Implementations can combine testing for cycles and other well-formedness
+or validity requirements together with other processing for rendering the color
+glyph.
+
+If the graph contains a cycle or is otherwise not well formed or valid, the
+paint table at which the error occurs should be ignored, that sub-graph should
+not be rendered, and that node in the graph should be considered to be visually
+bounded. The application should attempt to render the remainder of the graph, if
+well formed and valid.
+
+Future minor version updates of the COLR table could introduce new paint
+formats. If a paint table with an unrecognized format is encountered, it and its
+sub-graph should similarly be ignored, the node should be considered to be
+visually bounded, and the application should attempt to render the remainder of
+the graph.
+
+If an application is not able to recover from errors while traversing the graph,
+it may ignore the color glyph entirely. If the base glyph ID has an outline,
+that may be rendered as a non-color glyph instead.
 
 **5.7.11.2 COLR table formats**
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -1449,10 +1449,9 @@ For the graph to be acyclic, no paint table shall have any child or descendent
 paint table that is also its parent or ancestor within the graph. In particular,
 because the PaintColrLayers and PaintColrGlyph tables use indirect child
 references rather than forward offsets, they provide a possibility for
-introducing cycles. Applications can test for cycles by tracking paint tables
-used in a sequence within the graph and then, when processing a PaintColrLayers
-or PaintColrGlyph table, checking whether any child was already encountered
-within that sequence. The following pseudo-code algorithm can be used:
+introducing cycles. Applications should track paint tables within a path in the
+graph, checking whether any paint table was already encountered within that
+path. The following pseudo-code algorithm can be used:
 
 ```
     // called initially with the root paint and an empty set activePaints
@@ -1472,19 +1471,13 @@ For the graph to be valid, it shall also be visually bounded, as described in
 5.7.11.1.8.2.
 
 If the graph is not well formed, the entire color glyph definition should be
-considered invalid. In particular, applications should not simply ignore a
-sub-graph when an error in a paint table is detected since that could result in
-a visually unbounded color glyph definition. For instance, if a PaintColrGlyph
-table is found to introduce a cycle or there isn't a corresponding
-BaseGlyphV1Record, the remainder of the graph if that PaintColrGlyph table and
-its sub-graph are ignored could be unbounded. For this reason, if the graph is
-not well formed, the entire color glyph definition should be ignored. If the
-base glyph ID has an outline, that may be rendered instead.
+considered invalid.  Similarly, if an application encounters a paint table with
+an unrecognized format (which could be introduced in a later minor version
+update of the COLR table), the color glyph should be ignored. If the base glyph
+ID has an outline, that may be rendered as a non-color glyph instead.
 
-Similarly, if an application encounters a paint table with an unrecognized
-format (which could be introduced in a later minor version update of the COLR
-table), the remainder of the graph could be visually unbounded, therefore the
-color glyph should be ignored.
+NOTE: If a sub-graph is ignored, the remainder of the graph could be visually
+unbounded and, therefore, invalid.
 
 **5.7.11.2 COLR table formats**
 


### PR DESCRIPTION
Coming back to #168 — this is the issue that, if a sub-graph is ignored (e.g., the glyphID in PaintColrGlyph is bad), then the remainder of the graph could be unbounded.