### PR TITLE
tweak rendering algo wording

### DIFF
--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -2186,7 +2186,8 @@ NOTE: Checks for well-formedness and validity, as described in 5.7.11.1.9, are n
 function renderPaint(paint)
 
     if format 1: // PaintColrLayers
-        for each referenced child paint table, in bottom-up z-order (see 5.7.11.1.4, 5.7.11.2.5.1):
+        for each referenced child paint table, in bottom-up z-order:
+            // for ordering, see 5.7.11.1.4, 5.7.11.2.5.1
             call renderPaint() passing the child paint table
             compose the returned graphic onto the surface using simple alpha blending
 
@@ -2198,7 +2199,8 @@ function renderPaint(paint)
         paint the gradient onto the surface following the gradient algorithm
 
     if format 5: // PaintGlyph
-        use the referenced glyph outline to set a clip region
+        apply the outline of the referenced glyph to the clip region
+            // take the intersection of clip regions—see 5.7.11.1.3
         call renderPaint() passing the child paint table
         restore the previous clip region
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -2212,6 +2212,7 @@ function renderPaint(paint)
     or if format 9: // PaintRotate
     or if format 10: // PaintSkew
         apply the specified transform
+            // compose the transform with the current transform state—see 5.7.11.1.5
         call renderPaint() passing the child paint table
         restore the previous transform state
 


### PR DESCRIPTION
Small wording change in the rendering algorithm to clarify applying glyph outlines to the clip region (intersect current clip, i.e., do just replace the clip)