### PR TITLE
PaintSweepGradient: rename x -> centerX, y -> centerY

### DIFF
--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1570,8 +1570,8 @@ For information about applying a fill to a shape, see 5.7.11.1.3.
 |-|-|-|
 | uint8 | format | Set to 5. |
 | Offset24 | colorLineOffset | Offset to ColorLine table. |
-| VarFWord | x | Center x coordinate. |
-| VarFWord | y | Center y coordinate. |
+| VarFWord | centerX | Center x coordinate. |
+| VarFWord | centerY | Center y coordinate. |
 | VarFixed | startAngle | Start of the angular range of the gradient. |
 | VarFixed | endAngle | End of the angular range of the gradient. |
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -235,8 +235,8 @@ struct PaintSweepGradient
 {
   uint8               format; // = 5
   Offset24<ColorLine> colorLine;
-  VarFWORD            x;
-  VarFWORD            y;
+  VarFWORD            centerX;
+  VarFWORD            centerY;
   VarFixed            startAngle;
   VarFixed            endAngle;
 };


### PR DESCRIPTION
`PaintRotate` and `PaintSkew` contain `centerX` and `centerY` for their respective center point, would be nice if also PaintSweepGradient used the same nomenclature for consistency.