### PR TITLE
Start revisions to add no-var formats

### DIFF
--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1579,9 +1579,10 @@ ItemVariationStore subtable.
 For general information about linear gradients, see 5.7.11.1.2.2. For
 information about applying a fill to a shape, see 5.7.11.1.3.
 
-The PaintLinearGradient and PaintVarLinearGradient tables have a ColorLine
-subtable. For the ColorLine table format, see 5.7.11.2.4. For background
-information on the color line, see 5.7.11.1.2.1.
+The PaintLinearGradient and PaintVarLinearGradient tables have a ColorLine and
+VarColorLine subtable, respectively. For the ColorLine and VarColorLine table
+formats, see 5.7.11.2.4. For background information on the color line, see
+5.7.11.1.2.1.
 
 *PaintLinearGradient table (format 4):*
 
@@ -1620,9 +1621,10 @@ ItemVariationStore subtable.
 For general information about radial gradients supported in COLR version 1, see
 5.7.11.1.2.3. For information about applying a fill to a shape, see 5.7.11.1.3.
 
-The PaintRadialGradient and PaintVarRadialGradient tables have a ColorLine
-subtable. For the ColorLine table format, see in 5.7.11.2.4. For background
-information on the color line, see 5.7.11.1.2.1.
+The PaintRadialGradient and PaintVarRadialGradient tables have a ColorLine and
+VarColorLine subtable, respectively. For the ColorLine and VarColorLine table
+formats, see in 5.7.11.2.4. For background information on the color line, see
+5.7.11.1.2.1.
 
 *PaintRadialGradient table (format 6):*
 
@@ -1661,9 +1663,10 @@ ItemVariationStore subtable.
 For general information about sweep gradients, see 5.7.11.1.2.4. For information
 about applying a fill to a shape, see 5.7.11.1.3.
 
-The PaintSweepGradient and PaintVarSweepGradient table have a ColorLine
-subtable. For the ColorLine table format, see 5.7.11.2.4. For background
-information on the color line, see 5.7.11.1.2.1.
+The PaintSweepGradient and PaintVarSweepGradient table have a ColorLine and
+VarColorLine subtable, respectively. For the ColorLine and VarColorLine table
+formats, see 5.7.11.2.4. For background information on the color line, see
+5.7.11.1.2.1.
 
 *PaintSweepGradient table (format 8):*
 

--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1590,12 +1590,12 @@ formats, see 5.7.11.2.4. For background information on the color line, see
 |-|-|-|
 | uint8 | format | Set to 4. |
 | Offset24 | colorLineOffset | Offset to ColorLine table. |
-| FWord | x0 | Start point (p₀) x coordinate. |
-| FWord | y0 | Start point (p₀) y coordinate. |
-| FWord | x1 | End point (p₁) x coordinate. |
-| FWord | y1 | End point (p₁) y coordinate. |
-| FWord | x2 | Rotation point (p₂) x coordinate. |
-| FWord | y2 | Rotation point (p₂) y coordinate. |
+| FWORD | x0 | Start point (p₀) x coordinate. |
+| FWORD | y0 | Start point (p₀) y coordinate. |
+| FWORD | x1 | End point (p₁) x coordinate. |
+| FWORD | y1 | End point (p₁) y coordinate. |
+| FWORD | x2 | Rotation point (p₂) x coordinate. |
+| FWORD | y2 | Rotation point (p₂) y coordinate. |
 
 *PaintVarLinearGradient table (format 5):*
 
@@ -1632,12 +1632,12 @@ formats, see in 5.7.11.2.4. For background information on the color line, see
 |-|-|-|
 | uint8 | format | Set to 6. |
 | Offset24 | colorLineOffset | Offset to ColorLine table. |
-| FWord | x0 | Start circle center x coordinate. |
-| FWord | y0 | Start circle center y coordinate. |
-| UFWord | radius0 | Start circle radius. |
-| FWord | x1 | End circle center x coordinate. |
-| FWord | y1 | End circle center y coordinate. |
-| UFWord | radius1 | End circle radius. |
+| FWORD | x0 | Start circle center x coordinate. |
+| FWORD | y0 | Start circle center y coordinate. |
+| UFWORD | radius0 | Start circle radius. |
+| FWORD | x1 | End circle center x coordinate. |
+| FWORD | y1 | End circle center y coordinate. |
+| UFWORD | radius1 | End circle radius. |
 
 *PaintVarRadialGradient table (format 7):*
 
@@ -1674,8 +1674,8 @@ formats, see 5.7.11.2.4. For background information on the color line, see
 |-|-|-|
 | uint8 | format | Set to 8. |
 | Offset24 | colorLineOffset | Offset to ColorLine table. |
-| FWord | centerX | Center x coordinate. |
-| FWord | centerY | Center y coordinate. |
+| FWORD | centerX | Center x coordinate. |
+| FWORD | centerY | Center y coordinate. |
 | Fixed | startAngle | Start of the angular range of the gradient. |
 | Fixed | endAngle | End of the angular range of the gradient. |
 
@@ -2365,7 +2365,7 @@ VarFWord record is used to represent a coordinate that can be variable.
 
 #### VarUFWord
 
-The UFWord type is used to represent distances in the glyph design grid. The
+The UFWORD type is used to represent distances in the glyph design grid. The
 VarUFWord record is used to represent a distance that can be variable.
 
 | Type | Name | Description |
@@ -2382,7 +2382,7 @@ used to represent such a value that can be variable.
 
 | Type | Name | Description |
 |-|-|-|
-| F2Dot14 | value | |
+| F2DOT14 | value | |
 | uint16 | varOuterIndex | |
 | uint16 | varInnerIndex | |
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -107,13 +107,25 @@ typedef Variable<F2DOT14> VarF2DOT14;
 struct ColorIndex
 {
   uint16     paletteIndex;
+  F2DOT14 alpha; // Default 1.0. Values outside [0.,1.] reserved.
+};
+
+struct VarColorIndex
+{
+  uint16     paletteIndex;
   VarF2DOT14 alpha; // Default 1.0. Values outside [0.,1.] reserved.
 };
 
 struct ColorStop
 {
-  VarF2DOT14 stopOffset;
+  F2DOT14 stopOffset;
   ColorIndex color;
+};
+
+struct VarColorStop
+{
+  VarF2DOT14 stopOffset;
+  VarColorIndex color;
 };
 
 enum Extend : uint8
@@ -127,6 +139,12 @@ struct ColorLine
 {
   Extend             extend;
   ArrayOf<ColorStop> stops;
+};
+
+struct VarColorLine
+{
+  Extend             extend;
+  ArrayOf<VarColorStop> stops;
 };
 
 
@@ -180,6 +198,16 @@ enum CompositeMode : uint8
 // This is a standard 2x3 matrix for 2D affine transformation.
 struct Affine2x3
 {
+  Fixed xx;
+  Fixed yx;
+  Fixed xy;
+  Fixed yy;
+  Fixed dx;
+  Fixed dy;
+};
+
+struct VarAffine2x3
+{
   VarFixed xx;
   VarFixed yx;
   VarFixed xy;
@@ -207,95 +235,169 @@ struct PaintSolid
   ColorIndex color;
 };
 
+struct PaintVarSolid
+{
+  uint8      format; // = 3
+  VarColorIndex color;
+};
+
 struct PaintLinearGradient
 {
-  uint8               format; // = 3
-  Offset24<ColorLine> colorLine;
-  VarFWORD            x0;
-  VarFWORD            y0;
-  VarFWORD            x1;
-  VarFWORD            y1;
-  VarFWORD            x2; // Normal; Equal to (x1,y1) in simple cases.
-  VarFWORD            y2;
+  uint8                  format; // = 4
+  Offset24<ColorLine>    colorLine;
+  FWORD                  x0;
+  FWORD                  y0;
+  FWORD                  x1;
+  FWORD                  y1;
+  FWORD                  x2; // Normal; Equal to (x1,y1) in simple cases.
+  FWORD                  y2;
+};
+
+struct PaintVarLinearGradient
+{
+  uint8                  format; // = 5
+  Offset24<VarColorLine> colorLine;
+  VarFWORD               x0;
+  VarFWORD               y0;
+  VarFWORD               x1;
+  VarFWORD               y1;
+  VarFWORD               x2; // Normal; Equal to (x1,y1) in simple cases.
+  VarFWORD               y2;
 };
 
 struct PaintRadialGradient
 {
-  uint8               format; // = 4
-  Offset24<ColorLine> colorLine;
-  VarFWORD            x0;
-  VarFWORD            y0;
-  VarUFWORD           radius0;
-  VarFWORD            x1;
-  VarFWORD            y1;
-  VarUFWORD           radius1;
+  uint8                  format; // = 6
+  Offset24<ColorLine>    colorLine;
+  FWORD                  x0;
+  FWORD                  y0;
+  UFWORD                 radius0;
+  FWORD                  x1;
+  FWORD                  y1;
+  UFWORD                 radius1;
+};
+
+struct PaintVarRadialGradient
+{
+  uint8                  format; // = 7
+  Offset24<VarColorLine> colorLine;
+  VarFWORD               x0;
+  VarFWORD               y0;
+  VarUFWORD              radius0;
+  VarFWORD               x1;
+  VarFWORD               y1;
+  VarUFWORD              radius1;
 };
 
 struct PaintSweepGradient
 {
-  uint8               format; // = 5
-  Offset24<ColorLine> colorLine;
-  VarFWORD            centerX;
-  VarFWORD            centerY;
-  VarFixed            startAngle;
-  VarFixed            endAngle;
+  uint8                  format; // = 8
+  Offset24<ColorLine>    colorLine;
+  FWORD                  centerX;
+  FWORD                  centerY;
+  Fixed                  startAngle;
+  Fixed                  endAngle;
+};
+
+struct PaintVarSweepGradient
+{
+  uint8                  format; // = 9
+  Offset24<VarColorLine> colorLine;
+  VarFWORD               centerX;
+  VarFWORD               centerY;
+  VarFixed               startAngle;
+  VarFixed               endAngle;
 };
 
 // Paint a non-COLR glyph, filled as indicated by paint.
 struct PaintGlyph
 {
-  uint8               format; // = 6
-  Offset24<Paint>     paint;
-  uint16              gid;    // not a COLR-only gid
-                              // shall be less than maxp.numGlyphs
+  uint8                  format; // = 10
+  Offset24<Paint>        paint;
+  uint16                 gid;    // not a COLR-only gid
+                                 // shall be less than maxp.numGlyphs
 }
 
 struct PaintColrGlyph
 {
-  uint8               format; // = 7
-  uint16              gid;    // shall be a COLR gid
+  uint8                  format; // = 11
+  uint16                 gid;    // shall be a COLR gid
 }
 
 struct PaintTransform
 {
-  uint8               format; // = 8
-  Offset24<Paint>     src;
-  Affine2x3           transform;
+  uint8                  format; // = 12
+  Offset24<Paint>        src;
+  Affine2x3              transform;
+};
+
+struct PaintVarTransform
+{
+  uint8                  format; // = 13
+  Offset24<Paint>        src;
+  VarAffine2x3           transform;
 };
 
 struct PaintTranslate
 {
-  uint8               format; // = 9
-  Offset24<Paint>     src;
-  VarFixed            dx;
-  VarFixed            dy;
+  uint8                  format; // = 14
+  Offset24<Paint>        src;
+  Fixed                  dx;
+  Fixed                  dy;
+};
+
+struct PaintVarTranslate
+{
+  uint8                  format; // = 15
+  Offset24<Paint>        src;
+  VarFixed               dx;
+  VarFixed               dy;
 };
 
 struct PaintRotate
 {
-  uint8               format; // = 10
-  Offset24<Paint>     src;
-  VarFixed            angle;
-  VarFixed            centerX;
-  VarFixed            centerY;
+  uint8                  format; // = 16
+  Offset24<Paint>        src;
+  Fixed                  angle;
+  Fixed                  centerX;
+  Fixed                  centerY;
+};
+
+struct PaintVarRotate
+{
+  uint8                  format; // = 17
+  Offset24<Paint>        src;
+  VarFixed               angle;
+  VarFixed               centerX;
+  VarFixed               centerY;
 };
 
 struct PaintSkew
 {
-  uint8               format; // = 11
-  Offset24<Paint>     src;
-  VarFixed            xSkewAngle;
-  VarFixed            ySkewAngle;
-  VarFixed            centerX;
-  VarFixed            centerY;
+  uint8                  format; // = 18
+  Offset24<Paint>        src;
+  Fixed                  xSkewAngle;
+  Fixed                  ySkewAngle;
+  Fixed                  centerX;
+  Fixed                  centerY;
+};
+
+struct PaintVarSkew
+{
+  uint8                  format; // = 19
+  Offset24<Paint>        src;
+  VarFixed               xSkewAngle;
+  VarFixed               ySkewAngle;
+  VarFixed               centerX;
+  VarFixed               centerY;
 };
 
 struct PaintComposite
 {
-  uint8               format; // = 12
-  Offset24<Paint>     src;
-  CompositeMode       mode;   // If mode is unrecognized use COMPOSITE_CLEAR
-  Offset24<Paint>     backdrop;
+  uint8                  format; // = 20
+  Offset24<Paint>        src;
+  CompositeMode          mode;   // If mode is unrecognized use COMPOSITE_CLEAR
+  Offset24<Paint>        backdrop;
 };
 
 struct BaseGlyphV1Record


### PR DESCRIPTION
This is a start of the changes needed to add v1 formats without variation indices. This adds additional formats for gradients, but not yet for transforms.

I'll also need to look through the entire doc to see where else changes will be needed. And colr-gradients-spec.md will also need updating.