### PR TITLE
Reduce precision for all transforms added for compactness

### DIFF
--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1913,7 +1913,7 @@ provides a more compact representation when variation is not required. Format 15
 shall not be used in non-variable fonts or if the COLR table does not have an
 ItemVariationStore subtable.
 
-These tables used reduced precision for compactness. Where higher precision is
+These tables use reduced precision for compactness. Where higher precision is
 required use PaintTransform/PaintVarTransform.
 
 For general information regarding transformations in a color glyph definition, 

--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1973,7 +1973,7 @@ is not required.
 Formats 17, 19, 21 and 23 shall not be used in non-variable fonts or if the COLR
 table does not have an ItemVariationStore subtable.
 
-These tables used reduced precision for compactness. Where higher precision is
+These tables use reduced precision for compactness. Where higher precision is
 required use PaintTransform/PaintVarTransform.
 
 For general information regarding transformations in a color glyph definition, 

--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1925,8 +1925,8 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 14. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| Int16 | dx | Translation in x direction. |
-| Int16 | dy | Translation in y direction. |
+| FWORD | dx | Translation in x direction. |
+| FWORD | dy | Translation in y direction. |
 
 *PaintVarTranslate table (format 15):*
 
@@ -1934,8 +1934,8 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 15. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| VarInt16 | dx | Translation in x direction. |
-| VarInt16 | dy | Translation in y direction. |
+| VarFWORD | dx | Translation in x direction. |
+| VarFWORD | dy | Translation in y direction. |
 
 NOTE: Pure translation can also be represented using the PaintTransform or
 PaintVarTransform table by setting _xx_ = 1, _yy_ = 1, _xy_ and _yx_ = 0, and
@@ -2005,8 +2005,8 @@ see 5.7.11.1.5.
 | Offset24 | paintOffset | Offset to a Paint subtable. |
 | F2Dot14 | scaleX | Scale factor in x direction. |
 | F2Dot14 | scaleY | Scale factor in y direction. |
-| Int16 | centerX | x coordinate for the center of scaling. |
-| Int16 | centerY | y coordinate for the center of scaling. |
+| Fixed | centerX | x coordinate for the center of scaling. |
+| Fixed | centerY | y coordinate for the center of scaling. |
 
 *PaintVarScaleAroundCenter table (format 19):*
 
@@ -2016,8 +2016,8 @@ see 5.7.11.1.5.
 | Offset24 | paintOffset | Offset to a Paint subtable. |
 | VarF2Dot14 | scaleX | Scale factor in x direction. |
 | VarF2Dot14 | scaleY | Scale factor in y direction. |
-| VarInt16 | centerX | x coordinate for the center of scaling. |
-| VarInt16 | centerY | y coordinate for the center of scaling. |
+| VarFixed | centerX | x coordinate for the center of scaling. |
+| VarFixed | centerY | y coordinate for the center of scaling. |
 
 *PaintScaleUniform table (format 20):*
 
@@ -2042,8 +2042,8 @@ see 5.7.11.1.5.
 | uint8 | format | Set to 22. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
 | F2Dot14 | scale | Scale factor in x and y directions. |
-| Int16 | centerX | x coordinate for the center of scaling. |
-| Int16 | centerY | y coordinate for the center of scaling. |
+| Fixed | centerX | x coordinate for the center of scaling. |
+| Fixed | centerY | y coordinate for the center of scaling. |
 
 *PaintVarScaleUniformAroundCenter table (format 23):*
 
@@ -2052,8 +2052,8 @@ see 5.7.11.1.5.
 | uint8 | format | Set to 23. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
 | VarF2Dot14 | scale | Scale factor in x and y directions. |
-| VarInt16 | centerX | x coordinate for the center of scaling. |
-| VarInt16 | centerY | y coordinate for the center of scaling. |
+| VarFixed | centerX | x coordinate for the center of scaling. |
+| VarFixed | centerY | y coordinate for the center of scaling. |
 
 NOTE: Pure scaling can also be represented using the PaintTransform or
 PaintVarTransform table. For scaling about the origin, this could be done by
@@ -2109,8 +2109,8 @@ see 5.7.11.1.5.
 | uint8 | format | Set to 26. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
 | F2Dot14 | angle | Rotation angle, 180° in counter-clockwise degrees per 1.0 of value. |
-| Int16 | centerX | x coordinate for the center of rotation. |
-| Int16 | centerY | y coordinate for the center of rotation. |
+| Fixed | centerX | x coordinate for the center of rotation. |
+| Fixed | centerY | y coordinate for the center of rotation. |
 
 *PaintVarRotateAroundCenter table (format 27):*
 
@@ -2119,8 +2119,8 @@ see 5.7.11.1.5.
 | uint8 | format | Set to 27. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
 | VarF2Dot14 | angle | Rotation angle, 180° in counter-clockwise degrees per 1.0 of value |
-| VarInt16 | centerX | x coordinate for the center of rotation. |
-| VarInt16 | centerY | y coordinate for the center of rotation. |
+| VarFixed | centerX | x coordinate for the center of rotation. |
+| VarFixed | centerY | y coordinate for the center of rotation. |
 
 NOTE: Pure rotation about a point can also be represented using the
 PaintTransform or PaintVarTransform table. For rotation about the origin, this
@@ -2193,8 +2193,8 @@ see 5.7.11.1.5.
 | Offset24 | paintOffset | Offset to a Paint subtable. |
 | F2Dot14 | xSkewAngle | Angle of skew in the direction of the x-axis, 180° in counter-clockwise degrees per 1.0 of value. |
 | F2Dot14 | ySkewAngle | Angle of skew in the direction of the y-axis, 180° in counter-clockwise degrees per 1.0 of value. |
-| Int16 | centerX | x coordinate for the center of rotation. |
-| Int16 | centerY | y coordinate for the center of rotation. |
+| Fixed | centerX | x coordinate for the center of rotation. |
+| Fixed | centerY | y coordinate for the center of rotation. |
 
 *PaintVarSkewAroundCenter table (format 31):*
 
@@ -2204,8 +2204,8 @@ see 5.7.11.1.5.
 | Offset24 | paintOffset | Offset to a Paint subtable. |
 | VarF2Dot14 | xSkewAngle | Angle of skew in the direction of the x-axis, 180° in counter-clockwise degrees per 1.0 of value. |
 | VarF2Dot14 | ySkewAngle | Angle of skew in the direction of the y-axis, 180° in counter-clockwise degrees per 1.0 of value. |
-| VarInt16 | centerX | x coordinate for the center of rotation. |
-| VarInt16 | centerY | y coordinate for the center of rotation. |
+| VarFixed | centerX | x coordinate for the center of rotation. |
+| Fixed | centerY | y coordinate for the center of rotation. |
 
 NOTE: Pure skews about a point can also be represented using the PaintTransform
 or PaintVarTransform table. For skews about the origin, this could be done by

--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1913,6 +1913,9 @@ provides a more compact representation when variation is not required. Format 15
 shall not be used in non-variable fonts or if the COLR table does not have an
 ItemVariationStore subtable.
 
+These tables used reduced precision for compactness. Where higher precision is
+required use PaintTransform/PaintVarTransform.
+
 For general information regarding transformations in a color glyph definition, 
 see 5.7.11.1.5.
 
@@ -1922,8 +1925,8 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 14. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| Fixed | dx | Translation in x direction. |
-| Fixed | dy | Translation in y direction. |
+| Int16 | dx | Translation in x direction. |
+| Int16 | dy | Translation in y direction. |
 
 *PaintVarTranslate table (format 15):*
 
@@ -1931,8 +1934,8 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 15. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| VarFixed | dx | Translation in x direction. |
-| VarFixed | dy | Translation in y direction. |
+| VarInt16 | dx | Translation in x direction. |
+| VarInt16 | dy | Translation in y direction. |
 
 NOTE: Pure translation can also be represented using the PaintTransform or
 PaintVarTransform table by setting _xx_ = 1, _yy_ = 1, _xy_ and _yx_ = 0, and
@@ -1970,6 +1973,9 @@ is not required.
 Formats 17, 19, 21 and 23 shall not be used in non-variable fonts or if the COLR
 table does not have an ItemVariationStore subtable.
 
+These tables used reduced precision for compactness. Where higher precision is
+required use PaintTransform/PaintVarTransform.
+
 For general information regarding transformations in a color glyph definition, 
 see 5.7.11.1.5.
 
@@ -1979,8 +1985,8 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 16. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| Fixed | scaleX | Scale factor in x direction. |
-| Fixed | scaleY | Scale factor in y direction. |
+| F2Dot14 | scaleX | Scale factor in x direction. |
+| F2Dot14 | scaleY | Scale factor in y direction. |
 
 *PaintVarScale table (format 17):*
 
@@ -1988,8 +1994,8 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 17. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| VarFixed | scaleX | Scale factor in x direction. |
-| VarFixed | scaleY | Scale factor in y direction. |
+| VarF2Dot14 | scaleX | Scale factor in x direction. |
+| VarF2Dot14 | scaleY | Scale factor in y direction. |
 
 *PaintScaleAroundCenter table (format 18):*
 
@@ -1997,10 +2003,10 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 18. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| Fixed | scaleX | Scale factor in x direction. |
-| Fixed | scaleY | Scale factor in y direction. |
-| Fixed | centerX | x coordinate for the center of scaling. |
-| Fixed | centerY | y coordinate for the center of scaling. |
+| F2Dot14 | scaleX | Scale factor in x direction. |
+| F2Dot14 | scaleY | Scale factor in y direction. |
+| Int16 | centerX | x coordinate for the center of scaling. |
+| Int16 | centerY | y coordinate for the center of scaling. |
 
 *PaintVarScaleAroundCenter table (format 19):*
 
@@ -2008,10 +2014,10 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 19. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| VarFixed | scaleX | Scale factor in x direction. |
-| VarFixed | scaleY | Scale factor in y direction. |
-| VarFixed | centerX | x coordinate for the center of scaling. |
-| VarFixed | centerY | y coordinate for the center of scaling. |
+| VarF2Dot14 | scaleX | Scale factor in x direction. |
+| VarF2Dot14 | scaleY | Scale factor in y direction. |
+| VarInt16 | centerX | x coordinate for the center of scaling. |
+| VarInt16 | centerY | y coordinate for the center of scaling. |
 
 *PaintScaleUniform table (format 20):*
 
@@ -2019,7 +2025,7 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 20. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| Fixed | scale | Scale factor in x and y directions. |
+| F2Dot14 | scale | Scale factor in x and y directions. |
 
 *PaintVarScaleUniform table (format 21):*
 
@@ -2027,7 +2033,7 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 21. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| VarFixed | scale | Scale factor in x and y directions. |
+| VarF2Dot14 | scale | Scale factor in x and y directions. |
 
 *PaintScaleUniformAroundCenter table (format 22):*
 
@@ -2035,9 +2041,9 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 22. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| Fixed | scale | Scale factor in x and y directions. |
-| Fixed | centerX | x coordinate for the center of scaling. |
-| Fixed | centerY | y coordinate for the center of scaling. |
+| F2Dot14 | scale | Scale factor in x and y directions. |
+| Int16 | centerX | x coordinate for the center of scaling. |
+| Int16 | centerY | y coordinate for the center of scaling. |
 
 *PaintVarScaleUniformAroundCenter table (format 23):*
 
@@ -2045,9 +2051,9 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 23. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| VarFixed | scale | Scale factor in x and y directions. |
-| VarFixed | centerX | x coordinate for the center of scaling. |
-| VarFixed | centerY | y coordinate for the center of scaling. |
+| VarF2Dot14 | scale | Scale factor in x and y directions. |
+| VarInt16 | centerX | x coordinate for the center of scaling. |
+| VarInt16 | centerY | y coordinate for the center of scaling. |
 
 NOTE: Pure scaling can also be represented using the PaintTransform or
 PaintVarTransform table. For scaling about the origin, this could be done by
@@ -2059,7 +2065,8 @@ scaling is required.
 
 Formats 24 to 27 are used to apply a rotation to a sub-graph. The paint table
 that is the root of the sub-graph is linked as a child. The amount of rotation
-is expressed directly as an angle.
+is expressed as a floating point value where each 1.0 is 180°. This allows an
+F2Dot14 to be used for compact expression of rotation. 
 
 Formats 24 and 25 apply rotations using the origin as the center of rotation.
 Format 25 allows for variation of the rotation in a variable font; format 24
@@ -2073,6 +2080,9 @@ when variation is not required.
 Formats 25 and 27 shall not be used in non-variable fonts or if the COLR table
 does not have an ItemVariationStore subtable.
 
+These tables used reduced precision for compactness. Where higher precision is
+required use PaintTransform/PaintVarTransform.
+
 For general information regarding transformations in a color glyph definition,
 see 5.7.11.1.5.
 
@@ -2082,7 +2092,7 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 24. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| Fixed | angle | Rotation angle, in counter-clockwise degrees. |
+| F2Dot14 | angle | Rotation angle, 180° in counter-clockwise degrees per 1.0 of value. |
 
 *PaintVarRotate table (format 25):*
 
@@ -2090,7 +2100,7 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 25. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| VarFixed | angle | Rotation angle, in counter-clockwise degrees. |
+| VarF2Dot14 | angle | Rotation angle, 180° in counter-clockwise degrees per 1.0 of value. |
 
 *PaintRotateAroundCenter table (format 26):*
 
@@ -2098,9 +2108,9 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 26. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| Fixed | angle | Rotation angle, in counter-clockwise degrees. |
-| Fixed | centerX | x coordinate for the center of rotation. |
-| Fixed | centerY | y coordinate for the center of rotation. |
+| F2Dot14 | angle | Rotation angle, 180° in counter-clockwise degrees per 1.0 of value. |
+| Int16 | centerX | x coordinate for the center of rotation. |
+| Int16 | centerY | y coordinate for the center of rotation. |
 
 *PaintVarRotateAroundCenter table (format 27):*
 
@@ -2108,9 +2118,9 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 27. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| VarFixed | angle | Rotation angle, in counter-clockwise degrees. |
-| VarFixed | centerX | x coordinate for the center of rotation. |
-| VarFixed | centerY | y coordinate for the center of rotation. |
+| VarF2Dot14 | angle | Rotation angle, 180° in counter-clockwise degrees per 1.0 of value |
+| VarInt16 | centerX | x coordinate for the center of rotation. |
+| VarInt16 | centerY | y coordinate for the center of rotation. |
 
 NOTE: Pure rotation about a point can also be represented using the
 PaintTransform or PaintVarTransform table. For rotation about the origin, this
@@ -2163,8 +2173,8 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 28. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| Fixed | xSkewAngle | Angle of skew in the direction of the x-axis, in counter-clockwise degrees. |
-| Fixed | ySkewAngle | Angle of skew in the direction of the y-axis, in counter-clockwise degrees. |
+| F2Dot14 | xSkewAngle | Angle of skew in the direction of the x-axis, 180° in counter-clockwise degrees per 1.0 of value. |
+| F2Dot14 | ySkewAngle | Angle of skew in the direction of the y-axis, 180° in counter-clockwise degrees per 1.0 of value. |
 
 *PaintVarSkew table (format 29):*
 
@@ -2172,8 +2182,8 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 29. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| VarFixed | xSkewAngle | Angle of skew in the direction of the x-axis, in counter-clockwise degrees. |
-| VarFixed | ySkewAngle | Angle of skew in the direction of the y-axis, in counter-clockwise degrees. |
+| VarF2Dot14 | xSkewAngle | Angle of skew in the direction of the x-axis, 180° in counter-clockwise degrees per 1.0 of value. |
+| VarF2Dot14 | ySkewAngle | Angle of skew in the direction of the y-axis, 180° in counter-clockwise degrees per 1.0 of value. |
 
 *PaintSkewAroundCenter table (format 30):*
 
@@ -2181,10 +2191,10 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 30. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| Fixed | xSkewAngle | Angle of skew in the direction of the x-axis, in counter-clockwise degrees. |
-| Fixed | ySkewAngle | Angle of skew in the direction of the y-axis, in counter-clockwise degrees. |
-| Fixed | centerX | x coordinate for the center of rotation. |
-| Fixed | centerY | y coordinate for the center of rotation. |
+| F2Dot14 | xSkewAngle | Angle of skew in the direction of the x-axis, 180° in counter-clockwise degrees per 1.0 of value. |
+| F2Dot14 | ySkewAngle | Angle of skew in the direction of the y-axis, 180° in counter-clockwise degrees per 1.0 of value. |
+| Int16 | centerX | x coordinate for the center of rotation. |
+| Int16 | centerY | y coordinate for the center of rotation. |
 
 *PaintVarSkewAroundCenter table (format 31):*
 
@@ -2192,10 +2202,10 @@ see 5.7.11.1.5.
 |-|-|-|
 | uint8 | format | Set to 31. |
 | Offset24 | paintOffset | Offset to a Paint subtable. |
-| VarFixed | xSkewAngle | Angle of skew in the direction of the x-axis, in counter-clockwise degrees. |
-| VarFixed | ySkewAngle | Angle of skew in the direction of the y-axis, in counter-clockwise degrees. |
-| VarFixed | centerX | x coordinate for the center of rotation. |
-| VarFixed | centerY | y coordinate for the center of rotation. |
+| VarF2Dot14 | xSkewAngle | Angle of skew in the direction of the x-axis, 180° in counter-clockwise degrees per 1.0 of value. |
+| VarF2Dot14 | ySkewAngle | Angle of skew in the direction of the y-axis, 180° in counter-clockwise degrees per 1.0 of value. |
+| VarInt16 | centerX | x coordinate for the center of rotation. |
+| VarInt16 | centerY | y coordinate for the center of rotation. |
 
 NOTE: Pure skews about a point can also be represented using the PaintTransform
 or PaintVarTransform table. For skews about the origin, this could be done by

--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -2080,7 +2080,7 @@ when variation is not required.
 Formats 25 and 27 shall not be used in non-variable fonts or if the COLR table
 does not have an ItemVariationStore subtable.
 
-These tables used reduced precision for compactness. Where higher precision is
+These tables use reduced precision for compactness. Where higher precision is
 required use PaintTransform/PaintVarTransform.
 
 For general information regarding transformations in a color glyph definition,

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -367,152 +367,152 @@ struct PaintTranslate
 {
   uint8                  format; // = 14
   Offset24<Paint>        src;
-  Fixed                  dx;
-  Fixed                  dy;
+  Int16                  dx;
+  Int16                  dy;
 };
 
 struct PaintVarTranslate
 {
   uint8                  format; // = 15
   Offset24<Paint>        src;
-  VarFixed               dx;
-  VarFixed               dy;
+  VarInt16               dx;
+  VarInt16               dy;
 };
 
 struct PaintScale
 {
   uint8                  format; // = 16
   Offset24<Paint>        src;
-  Fixed                  scaleX;
-  Fixed                  scaleY;
+  F2Dot14                scaleX;
+  F2Dot14                scaleY;
 };
 
 struct PaintVarScale
 {
   uint8                  format; // = 17
   Offset24<Paint>        src;
-  VarFixed               scaleX;
-  VarFixed               scaleY;
+  VarF2Dot14             scaleX;
+  VarF2Dot14             scaleY;
 };
 
 struct PaintScaleAroundCenter
 {
   uint8                  format; // = 18
   Offset24<Paint>        src;
-  Fixed                  scaleX;
-  Fixed                  scaleY;
-  Fixed                  centerX;
-  Fixed                  centerY;
+  F2Dot14                scaleX;
+  F2Dot14                scaleY;
+  Int16                  centerX;
+  Int16                  centerY;
 };
 
 struct PaintVarScaleAroundCenter
 {
   uint8                  format; // = 19
   Offset24<Paint>        src;
-  VarFixed               scaleX;
-  VarFixed               scaleY;
-  VarFixed               centerX;
-  VarFixed               centerY;
+  VarF2Dot14             scaleX;
+  VarF2Dot14             scaleY;
+  VarInt16               centerX;
+  VarInt16               centerY;
 };
 
 struct PaintScaleUniform
 {
   uint8                  format; // = 20
   Offset24<Paint>        src;
-  Fixed                  scale;
+  F2Dot14                scale;
 };
 
 struct PaintVarScaleUniform
 {
   uint8                  format; // = 21
   Offset24<Paint>        src;
-  VarFixed               scale;
+  VarF2Dot14             scale;
 };
 
 struct PaintScaleUniformAroundCenter
 {
   uint8                  format; // = 22
   Offset24<Paint>        src;
-  Fixed                  scale;
-  Fixed                  centerX;
-  Fixed                  centerY;
+  F2Dot14                scale;
+  Int16                  centerX;
+  Int16                  centerY;
 };
 
 struct PaintVarScaleUniformAroundCenter
 {
   uint8                  format; // = 23
   Offset24<Paint>        src;
-  VarFixed               scale;
-  VarFixed               centerX;
-  VarFixed               centerY;
+  VarF2Dot14             scale;
+  VarInt16               centerX;
+  VarInt16               centerY;
 };
 
 struct PaintRotate
 {
   uint8                  format; // = 24
   Offset24<Paint>        src;
-  Fixed                  angle;
+  F2Dot14                angle;
 };
 
 struct PaintVarRotate
 {
   uint8                  format; // = 25
   Offset24<Paint>        src;
-  VarFixed               angle;
+  VarF2Dot14             angle;
 };
 
 struct PaintRotateAroundCenter
 {
   uint8                  format; // = 26
   Offset24<Paint>        src;
-  Fixed                  angle;
-  Fixed                  centerX;
-  Fixed                  centerY;
+  F2Dot14                angle;
+  Int16                  centerX;
+  Int16                  centerY;
 };
 
 struct PaintVarRotateAroundCenter
 {
   uint8                  format; // = 27
   Offset24<Paint>        src;
-  VarFixed               angle;
-  VarFixed               centerX;
-  VarFixed               centerY;
+  VarF2Dot14             angle;
+  VarInt16               centerX;
+  VarInt16               centerY;
 };
 
 struct PaintSkew
 {
   uint8                  format; // = 28
   Offset24<Paint>        src;
-  Fixed                  xSkewAngle;
-  Fixed                  ySkewAngle;
+  F2Dot14                xSkewAngle;
+  F2Dot14                ySkewAngle;
 };
 
 struct PaintVarSkew
 {
   uint8                  format; // = 29
   Offset24<Paint>        src;
-  VarFixed               xSkewAngle;
-  VarFixed               ySkewAngle;
+  VarF2Dot14             xSkewAngle;
+  VarF2Dot14             ySkewAngle;
 };
 
 struct PaintSkewAroundCenter
 {
   uint8                  format; // = 30
   Offset24<Paint>        src;
-  Fixed                  xSkewAngle;
-  Fixed                  ySkewAngle;
-  Fixed                  centerX;
-  Fixed                  centerY;
+  F2Dot14                xSkewAngle;
+  F2Dot14                ySkewAngle;
+  Int16                  centerX;
+  Int16                  centerY;
 };
 
 struct PaintVarSkewAroundCenter
 {
   uint8                  format; // = 31
   Offset24<Paint>        src;
-  VarFixed               xSkewAngle;
-  VarFixed               ySkewAngle;
-  VarFixed               centerX;
-  VarFixed               centerY;
+  VarF2Dot14             xSkewAngle;
+  VarF2Dot14             ySkewAngle;
+  VarInt16               centerX;
+  VarInt16               centerY;
 };
 
 struct PaintComposite

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -367,16 +367,16 @@ struct PaintTranslate
 {
   uint8                  format; // = 14
   Offset24<Paint>        src;
-  Int16                  dx;
-  Int16                  dy;
+  FWORD                  dx;
+  FWORD                  dy;
 };
 
 struct PaintVarTranslate
 {
   uint8                  format; // = 15
   Offset24<Paint>        src;
-  VarInt16               dx;
-  VarInt16               dy;
+  VarFWORD               dx;
+  VarFWORD               dy;
 };
 
 struct PaintScale
@@ -401,8 +401,8 @@ struct PaintScaleAroundCenter
   Offset24<Paint>        src;
   F2Dot14                scaleX;
   F2Dot14                scaleY;
-  Int16                  centerX;
-  Int16                  centerY;
+  Fixed                  centerX;
+  Fixed                  centerY;
 };
 
 struct PaintVarScaleAroundCenter
@@ -411,8 +411,8 @@ struct PaintVarScaleAroundCenter
   Offset24<Paint>        src;
   VarF2Dot14             scaleX;
   VarF2Dot14             scaleY;
-  VarInt16               centerX;
-  VarInt16               centerY;
+  VarFixed               centerX;
+  VarFixed               centerY;
 };
 
 struct PaintScaleUniform
@@ -434,8 +434,8 @@ struct PaintScaleUniformAroundCenter
   uint8                  format; // = 22
   Offset24<Paint>        src;
   F2Dot14                scale;
-  Int16                  centerX;
-  Int16                  centerY;
+  Fixed                  centerX;
+  Fixed                  centerY;
 };
 
 struct PaintVarScaleUniformAroundCenter
@@ -443,8 +443,8 @@ struct PaintVarScaleUniformAroundCenter
   uint8                  format; // = 23
   Offset24<Paint>        src;
   VarF2Dot14             scale;
-  VarInt16               centerX;
-  VarInt16               centerY;
+  VarFixed               centerX;
+  VarFixed               centerY;
 };
 
 struct PaintRotate
@@ -466,8 +466,8 @@ struct PaintRotateAroundCenter
   uint8                  format; // = 26
   Offset24<Paint>        src;
   F2Dot14                angle;
-  Int16                  centerX;
-  Int16                  centerY;
+  Fixed                  centerX;
+  Fixed                  centerY;
 };
 
 struct PaintVarRotateAroundCenter
@@ -475,8 +475,8 @@ struct PaintVarRotateAroundCenter
   uint8                  format; // = 27
   Offset24<Paint>        src;
   VarF2Dot14             angle;
-  VarInt16               centerX;
-  VarInt16               centerY;
+  VarFixed               centerX;
+  VarFixed               centerY;
 };
 
 struct PaintSkew
@@ -501,8 +501,8 @@ struct PaintSkewAroundCenter
   Offset24<Paint>        src;
   F2Dot14                xSkewAngle;
   F2Dot14                ySkewAngle;
-  Int16                  centerX;
-  Int16                  centerY;
+  Fixed                  centerX;
+  Fixed                  centerY;
 };
 
 struct PaintVarSkewAroundCenter
@@ -511,8 +511,8 @@ struct PaintVarSkewAroundCenter
   Offset24<Paint>        src;
   VarF2Dot14             xSkewAngle;
   VarF2Dot14             ySkewAngle;
-  VarInt16               centerX;
-  VarInt16               centerY;
+  VarFixed               centerX;
+  VarFixed               centerY;
 };
 
 struct PaintComposite

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -451,21 +451,21 @@ struct PaintRotate
 {
   uint8                  format; // = 24
   Offset24<Paint>        src;
-  F2Dot14                angle;
+  F2Dot14                angle; // 180° in counter-clockwise degrees per 1.0 of value
 };
 
 struct PaintVarRotate
 {
   uint8                  format; // = 25
   Offset24<Paint>        src;
-  VarF2Dot14             angle;
+  VarF2Dot14             angle; // 180° in counter-clockwise degrees per 1.0 of value
 };
 
 struct PaintRotateAroundCenter
 {
   uint8                  format; // = 26
   Offset24<Paint>        src;
-  F2Dot14                angle;
+  F2Dot14                angle; // 180° in counter-clockwise degrees per 1.0 of value
   Fixed                  centerX;
   Fixed                  centerY;
 };
@@ -474,7 +474,7 @@ struct PaintVarRotateAroundCenter
 {
   uint8                  format; // = 27
   Offset24<Paint>        src;
-  VarF2Dot14             angle;
+  VarF2Dot14             angle; // 180° in counter-clockwise degrees per 1.0 of value
   VarFixed               centerX;
   VarFixed               centerY;
 };
@@ -483,24 +483,24 @@ struct PaintSkew
 {
   uint8                  format; // = 28
   Offset24<Paint>        src;
-  F2Dot14                xSkewAngle;
-  F2Dot14                ySkewAngle;
+  F2Dot14                xSkewAngle; // 180° in counter-clockwise degrees per 1.0 of value
+  F2Dot14                ySkewAngle; // 180° in counter-clockwise degrees per 1.0 of value
 };
 
 struct PaintVarSkew
 {
   uint8                  format; // = 29
   Offset24<Paint>        src;
-  VarF2Dot14             xSkewAngle;
-  VarF2Dot14             ySkewAngle;
+  VarF2Dot14             xSkewAngle; // 180° in counter-clockwise degrees per 1.0 of value
+  VarF2Dot14             ySkewAngle; // 180° in counter-clockwise degrees per 1.0 of value
 };
 
 struct PaintSkewAroundCenter
 {
   uint8                  format; // = 30
   Offset24<Paint>        src;
-  F2Dot14                xSkewAngle;
-  F2Dot14                ySkewAngle;
+  F2Dot14                xSkewAngle; // 180° in counter-clockwise degrees per 1.0 of value
+  F2Dot14                ySkewAngle; // 180° in counter-clockwise degrees per 1.0 of value
   Fixed                  centerX;
   Fixed                  centerY;
 };
@@ -509,8 +509,8 @@ struct PaintVarSkewAroundCenter
 {
   uint8                  format; // = 31
   Offset24<Paint>        src;
-  VarF2Dot14             xSkewAngle;
-  VarF2Dot14             ySkewAngle;
+  VarF2Dot14             xSkewAngle; // 180° in counter-clockwise degrees per 1.0 of value
+  VarF2Dot14             ySkewAngle; // 180° in counter-clockwise degrees per 1.0 of value
   VarFixed               centerX;
   VarFixed               centerY;
 };


### PR DESCRIPTION
Exploit the follow observations from test fonts:

1. The most common translation is by an integer that fits within int16 so change dx/dy to Int16
1. The most common rotation is by < 360° so change angles to F2Dot14 where 1.0 means 180° counter-clockwise
1. The most common scales are small, it's rare to want a massively larger/smaller version of something, so use F2Dot14 scales
1. The most common center for a transformation is an integer that fits within int16 so change centerX/Y to Int16

Note that:

1. In all cases full precision can be achieved by using the full 2x3 whose types are unchanged.
1. Variation can be used to access greater range, such as if you want an axis that causes many rotations.