### PR TITLE
Give COLR an explicit bbox to call it's own

### DIFF
--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1144,8 +1144,9 @@ For each color glyph, the bounding box for the color glyph is defined within
 the color glyph description (see 5.7.11.2.3). The bounding box data can be
 variable within a variable font.
 
-NOTE: The bounding box of the BaseGlyphPaintRecord can be used to allocate a drawing
-surface without needing to traverse the graph of the color glyph definition.
+NOTE: The bounding box data for the color glyph can be used to allocate a
+drawing surface without needing to traverse the graph of the color glyph
+definition.
 
 A valid color glyph definition shall define a bounded region—that is, it shall
 paint within a region for which a finite bounding box could be defined. The

--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1140,7 +1140,9 @@ used for the color glyph. The advance width and height of glyphs referenced by
 PaintGlyph tables are not required to be the same as that of the base glyph and
 are ignored.
 
-The BaseGlyphPaintRecord bbox provides the bounding box for the color glyph.
+For each color glyph, the bounding box for the color glyph is defined within
+the color glyph description (see 5.7.11.2.3). The bounding box data can be
+variable within a variable font.
 
 NOTE: The bounding box of the BaseGlyphPaintRecord can be used to allocate a drawing
 surface without needing to traverse the graph of the color glyph definition.
@@ -1439,16 +1441,6 @@ in COLR version 0, providing records that map a base glyph to a color glyph
 definition. The color glyph definitions that each refer to are significantly
 different, however—see 5.7.11.1.
 
-*VarBBox table:*
-
-| Type | Name | Description |
-|-|-|-|
-| FWORD | xMin | Minimum x of bounding box. For variation, use varIndexBase + 0. |
-| FWORD | yMin | Minimum y of bounding box. For variation, use varIndexBase + 1. |
-| FWORD | xMax | Maximum x of bounding box. For variation, use varIndexBase + 2. |
-| FWORD | yMax | Maximum y of bounding box. For variation, use varIndexBase + 3. |
-| uint32 | varIndexBase | Base index into DeltaSetIndexMap. |
-
 *BaseGlyphList table:*
 
 | Type | Name | Description |
@@ -1470,6 +1462,23 @@ table (5.2.6).
 The records in the baseGlyphPaintRecords array shall be sorted in increasing
 glyphID order. It is intended that a binary search can be used to find a
 matching BaseGlyphPaintRecord for a specific glyphID.
+
+A VarBBox subtable is used to provide the bounding box for the given color
+glyph.
+
+*VarBBox table:*
+
+| Type | Name | Description |
+|-|-|-|
+| FWORD | xMin | Minimum x of bounding box. For variation, use varIndexBase + 0. |
+| FWORD | yMin | Minimum y of bounding box. For variation, use varIndexBase + 1. |
+| FWORD | xMax | Maximum x of bounding box. For variation, use varIndexBase + 2. |
+| FWORD | yMax | Maximum y of bounding box. For variation, use varIndexBase + 3. |
+| uint32 | varIndexBase | Base index into DeltaSetIndexMap. |
+
+The same structure is used in both variable and non-variable fonts. For
+variable data, a base/sequence scheme is used to index into variation mapping
+data. See 5.7.11.4 for details.
 
 The paint table referenced by the BaseGlyphPaintRecord is the root of the graph
 for a color glyph definition.

--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1443,10 +1443,10 @@ different, however—see 5.7.11.1.
 
 | Type | Name | Description |
 |-|-|-|
-| UFWORD | x | x-coord of bounding box. For variation, use varIndexBase + 0. |
-| UFWORD | y | x-coord of bounding box. For variation, use varIndexBase + 1. |
-| UFWORD | w | width of bounding box. For variation, use varIndexBase + 2. |
-| UFWORD | h | height of bounding box. For variation, use varIndexBase + 3. |
+| FWORD | xMin | Minimum x of bounding box. For variation, use varIndexBase + 0. |
+| FWORD | yMin | Minimum y of bounding box. For variation, use varIndexBase + 1. |
+| FWORD | xMax | Maximum x of bounding box. For variation, use varIndexBase + 2. |
+| FWORD | yMax | Maximum y of bounding box. For variation, use varIndexBase + 3. |
 | uint32 | varIndexBase | Base index into DeltaSetIndexMap. |
 
 *BaseGlyphList table:*

--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1140,11 +1140,9 @@ used for the color glyph. The advance width and height of glyphs referenced by
 PaintGlyph tables are not required to be the same as that of the base glyph and
 are ignored.
 
-The bounding box of the base-glyph contours is used as the bounding box of the
-color glyph. A &#39;glyf&#39; entry with two points at diagonal extrema is
-sufficient to define the bounding box.
+The BaseGlyphPaintRecord bbox provides the bounding box for the color glyph.
 
-NOTE: The bounding box of the base glyph can be used to allocate a drawing
+NOTE: The bounding box of the BaseGlyphPaintRecord can be used to allocate a drawing
 surface without needing to traverse the graph of the color glyph definition.
 
 A valid color glyph definition shall define a bounded region—that is, it shall
@@ -1441,6 +1439,16 @@ in COLR version 0, providing records that map a base glyph to a color glyph
 definition. The color glyph definitions that each refer to are significantly
 different, however—see 5.7.11.1.
 
+*VarBBox table:*
+
+| Type | Name | Description |
+|-|-|-|
+| UFWORD | x | x-coord of bounding box. For variation, use varIndexBase + 0. |
+| UFWORD | y | x-coord of bounding box. For variation, use varIndexBase + 1. |
+| UFWORD | w | width of bounding box. For variation, use varIndexBase + 2. |
+| UFWORD | h | height of bounding box. For variation, use varIndexBase + 3. |
+| uint32 | varIndexBase | Base index into DeltaSetIndexMap. |
+
 *BaseGlyphList table:*
 
 | Type | Name | Description |
@@ -1454,6 +1462,7 @@ different, however—see 5.7.11.1.
 |-|-|-|
 | uint16 | glyphID | Glyph ID of the base glyph. |
 | Offset32 | paintOffset | Offset to a Paint table. |
+| Offset32 | bboxOffset | Offset to a VarBBox table. |
 
 The glyphID value shall be less than the numGlyphs value in the &#39;maxp&#39;
 table (5.2.6).

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -523,10 +523,10 @@ struct PaintComposite
 };
 
 struct VarBBox {
-  UFWORD                 x; // VarIdx varIndexBase + 0.
-  UFWORD                 y; // VarIdx varIndexBase + 1.
-  UFWORD                 w; // VarIdx varIndexBase + 2.
-  UFWORD                 h; // VarIdx varIndexBase + 3.
+  FWORD                 xMin; // VarIdx varIndexBase + 0.
+  FWORD                 yMin; // VarIdx varIndexBase + 1.
+  FWORD                 xMax; // VarIdx varIndexBase + 2.
+  FWORD                 yMax; // VarIdx varIndexBase + 3.
   VarIdxBase             varIndexBase;
 }
 

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -522,10 +522,19 @@ struct PaintComposite
   Offset24<Paint>        backdrop;
 };
 
+struct VarBBox {
+  UFWORD                 x; // VarIdx varIndexBase + 0.
+  UFWORD                 y; // VarIdx varIndexBase + 1.
+  UFWORD                 w; // VarIdx varIndexBase + 2.
+  UFWORD                 h; // VarIdx varIndexBase + 3.
+  VarIdxBase             varIndexBase;
+}
+
 struct BaseGlyphPaintRecord
 {
   uint16                gid;
   Offset32<Paint>       paint;  // Typically PaintColrLayers
+  Offset32<VarBBox>     bbox;
 };
 
 // Entries shall be sorted in ascending order of the `glyphID` field of the `BaseGlyphPaintRecord`s.

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -527,7 +527,7 @@ struct VarBBox {
   FWORD                 yMin; // VarIdx varIndexBase + 1.
   FWORD                 xMax; // VarIdx varIndexBase + 2.
   FWORD                 yMax; // VarIdx varIndexBase + 3.
-  VarIdxBase             varIndexBase;
+  VarIdxBase            varIndexBase; // Set to 0 in non-variable fonts.
 }
 
 struct BaseGlyphPaintRecord


### PR DESCRIPTION
Strawman for a fix for #251. Costs 16 bytes per BaseGlyphPaintRecord ... but for a font that doesn't _have_ an alternate presentation you get some of them back by not writing out bogus glyph records just to express bboxes (as our exploratory compiler does today).

Edit: Fixes #251