### PR TITLE
Rev DeltaSetIndexMap for formats 0 and 1

### DIFF
--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -2935,7 +2935,7 @@ Optional mapping subtables can also be used to provide delta-set indices for
 glyph side bearings. In variable fonts with TrueType outlines, variation data
 for side bearings is recommended. If variation data for side bearings is
 provided, it should include data for both left and right side bearings, and
-mapping subtables for left and right side bearings must also be included.
+mapping subtables for left and right side bearings shall also be included.
 
 _In subclause 7.3.5.2, after the table defnining the horizontal metrics
 variation table, replace the second and third paragraphs with the following:_


### PR DESCRIPTION
Change for #319.

This is a little involved since it requires pulling description of the DeltaSetIndexMap out of the HVAR section into the OT Var Common Formats section (as well as re-defining the structure and adding format 1).