### PR TITLE
define ClipList.format (0) to make it more futureproof

### DIFF
--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1519,6 +1519,7 @@ clip boxes for some color glyphs but not others.
 
 | Type | Name | Description |
 |-|-|-|
+| uint8 | format | Set to 0. |
 | uint32 | numClips | Number of Clip records. |
 | Clip | clips[numClips] | Clip records. Sorted by startGlyphID. |
 

--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1519,7 +1519,7 @@ clip boxes for some color glyphs but not others.
 
 | Type | Name | Description |
 |-|-|-|
-| uint8 | format | Set to 0. |
+| uint8 | format | Set to 1. |
 | uint32 | numClips | Number of Clip records. |
 | Clip | clips[numClips] | Clip records. Sorted by startGlyphID. |
 
@@ -1533,25 +1533,25 @@ clip boxes for some color glyphs but not others.
 
 Within a ClipList table, the glyph ID ranges of Clip records shall not overlap.
 
-Two Clipbox table formats are defined: format 0 for clip boxes without
-variation, and format 1 allowing for clip boxes that can vary in a variable
+Two Clipbox table formats are defined: format 1 for clip boxes without
+variation, and format 2 allowing for clip boxes that can vary in a variable
 font.
 
-*ClipBox table format 0, static clip box:*
+*ClipBox table format 1, static clip box:*
 
 | Type | Name | Description |
 |-|-|-|
-| uint8 | format | Set to 0. |
+| uint8 | format | Set to 1. |
 | FWORD | xMin | Minimum x of clip box. |
 | FWORD | yMin | Minimum y of clip box. |
 | FWORD | xMax | Maximum x of clip box. |
 | FWORD | yMax | Maximum y of clip box. |
 
-*ClipBox table format 1, variable clip box:*
+*ClipBox table format 2, variable clip box:*
 
 | Type | Name | Description |
 |-|-|-|
-| uint8 | format | Set to 1. |
+| uint8 | format | Set to 2. |
 | FWORD | xMin | Minimum x of clip box. For variation, use varIndexBase + 0. |
 | FWORD | yMin | Minimum y of clip box. For variation, use varIndexBase + 1. |
 | FWORD | xMax | Maximum x of clip box. For variation, use varIndexBase + 2. |

--- a/OFF_AMD2_WD.md
+++ b/OFF_AMD2_WD.md
@@ -1537,7 +1537,7 @@ Two Clipbox table formats are defined: format 1 for clip boxes without
 variation, and format 2 allowing for clip boxes that can vary in a variable
 font.
 
-*ClipBox table format 1, static clip box:*
+*ClipBoxFormat1, static clip box:*
 
 | Type | Name | Description |
 |-|-|-|
@@ -1547,7 +1547,7 @@ font.
 | FWORD | xMax | Maximum x of clip box. |
 | FWORD | yMax | Maximum y of clip box. |
 
-*ClipBox table format 2, variable clip box:*
+*ClipBoxFormat2, variable clip box:*
 
 | Type | Name | Description |
 |-|-|-|

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -558,7 +558,12 @@ typedef ArrayOf<BaseGlyphPaintRecord, uint32> BaseGlyphList;
 // Only layers accessed via PaintColrLayers (format 1) need be encoded here.
 typedef ArrayOf<Offset32<Paint>, uint32> LayerList;
 
-typedef ArrayOf<Clip, uint32> ClipList;
+struct ClipList
+{
+  uint8                 format;  // Set to 0.
+  uint32                numClips;
+  Clip                  clips[/*numClips*/];  // Clip records, sorted by startGlyphID
+}
 
 struct COLRv1
 {

--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -523,7 +523,7 @@ struct PaintComposite
 };
 
 struct ClipBox {
-  uint8                 format; // = 0
+  uint8                 format; // = 1
   FWORD                 xMin;
   FWORD                 yMin;
   FWORD                 xMax;
@@ -531,7 +531,7 @@ struct ClipBox {
 }
 
 struct VarClipBox {
-  uint8                 format; // = 1
+  uint8                 format; // = 2
   FWORD                 xMin; // VarIdx varIndexBase + 0.
   FWORD                 yMin; // VarIdx varIndexBase + 1.
   FWORD                 xMax; // VarIdx varIndexBase + 2.
@@ -560,7 +560,7 @@ typedef ArrayOf<Offset32<Paint>, uint32> LayerList;
 
 struct ClipList
 {
-  uint8                 format;  // Set to 0.
+  uint8                 format;  // Set to 1.
   uint32                numClips;
   Clip                  clips[/*numClips*/];  // Clip records, sorted by startGlyphID
 }


### PR DESCRIPTION
Fixes https://github.com/googlefonts/colr-gradients-spec/issues/346