### PR TITLE
Fix pseudocode for compositing step

### DIFF
--- a/colr-gradients-spec.md
+++ b/colr-gradients-spec.md
@@ -636,10 +636,12 @@ by traversing the paint graph to determine bounds.
           call a) for paint
           restore
     12) PaintComposite
+          saveLayer()
           paint Paint for backdrop, call a)
-          saveLayer() with setting composite mode, on SkPaint
+          saveLayer() with setting composite mode on SkPaint
           paint Paint for src, call a)
-          restore with save composite mode
+          restore with saved composite mode
+          restore the outer layer
 ```
 
 ## HarfBuzz


### PR DESCRIPTION
The pseudocode for compositing was missing one layer allocation. This
would result in incorrectly drawing BackdropPaint just on the previous
state of the canvas, then compositing the source paint down on
everything, instead of compositing backdrop and source first, then
applying the result to the current state of the canvas.